### PR TITLE
fix: Keys can contain strings or numbers

### DIFF
--- a/types.js.flow
+++ b/types.js.flow
@@ -4,7 +4,7 @@
  * manual types are more strict for fields, and are more useful in code
  */
 
-export type Key = string | Array<string>
+export type Key = string | Array<string | number>
 
 type BaseField = {|
   // A unique id used to reference the field from presets


### PR DESCRIPTION
Desktop allows a Key to contain strings or numbers, is this also the case for mobile?