### PR TITLE
feat!: update export names to improve type definition exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,18 @@ export { validateFilter };
 export { validateObservation };
 export { validatePreset };
 
+import CommonSchemaDef from './schema/common.json';
+import FieldSchemaDef from './schema/field.json';
+import FilterSchemaDef from './schema/filter.json';
+import ObservationSchemaDef from './schema/observation.json';
+import PresetSchemaDef from './schema/preset.json';
+
+export type CommonSchema = typeof CommonSchemaDef;
+export type FieldSchema = typeof FieldSchemaDef;
+export type FilterSchema = typeof FilterSchemaDef;
+export type ObservationSchema = typeof ObservationSchemaDef;
+export type PresetSchema = typeof PresetSchemaDef;
+
 export * from './types/Common';
 export * from './types/Field';
 export * from './types/Filter';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,17 @@
-import { validateCommon } from "./lib/validateCommon.js";
-import { validateField } from "./lib/validateField.js";
-import { validateFilter } from "./lib/validateFilter.js";
-import { validateObservation } from "./lib/validateObservation.js";
-import { validatePreset } from "./lib/validatePreset.js";
-export { validateCommon, validateField, validateFilter, validateObservation, validatePreset };
+import { validateCommon } from './lib/validateCommon.js';
+import { validateField } from './lib/validateField.js';
+import { validateFilter } from './lib/validateFilter.js';
+import { validateObservation } from './lib/validateObservation.js';
+import { validatePreset } from './lib/validatePreset.js';
+
+export { validateCommon };
+export { validateField };
+export { validateFilter };
+export { validateObservation };
+export { validatePreset };
+
+export * from './types/Common';
+export * from './types/Field';
+export * from './types/Filter';
+export * from './types/Observation';
+export * from './types/Preset';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JSON schema and flow types for Mapeo",
   "main": "index.js",
   "type": "module",
+  "types": "index.d.ts",
   "exports": {
     ".": "./index.js",
     "./validateCommon": "./lib/validateCommon.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,9 +47,7 @@ let schemaExports = ''
 let schemaDeclarationExports = ''
 
 moduleFilenames.forEach((filename) => {
-  moduleImports += `import { ${stripExt(
-    filename
-  )} } from './lib/${filename}';\n`
+  moduleImports += `import { ${stripExt(filename)} } from './lib/${filename}';\n`
   moduleExports += `export { ${stripExt(filename)} };\n`
 })
 


### PR DESCRIPTION
1. Adds the `types` field in `package.json`

2. Updates the build script to also export the TS interfaces for each entity in `./types/`

3. Updates the exported definition objects from the module to have a `Schema` suffix, e.g. `Common` is now `CommonSchema`. **This is a breaking change** although we can potentially avoid it by renaming the exported interfaces from the `./types/` directory instead, which I think is a little more difficult.


Note that this is pointing to `typescript` branch, not master