### PR TITLE
chore: remove build-command from release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,3 @@ jobs:
           npm-tag: ${{ startsWith('pre', github.event.inputs.semver) && 'next' || 'latest' }}
           # optional: set this secret in your repo config for publishing to NPM
           # npm-token: ${{ secrets.NPM_TOKEN }}
-          build-command: |
-            npm install
-            npm run build


### PR DESCRIPTION
npm build is triggered anyway by the `prepare` step.

Needing to create this as a PR because the workflow runs when I close this PR.