### PR TITLE
Revert "chore: remove build-command from release action (#50)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,6 @@ jobs:
           npm-tag: ${{ startsWith('pre', github.event.inputs.semver) && 'next' || 'latest' }}
           # optional: set this secret in your repo config for publishing to NPM
           # npm-token: ${{ secrets.NPM_TOKEN }}
+          build-command: |
+            npm install
+            npm run build


### PR DESCRIPTION
This reverts commit a355c7a7a1b75bd8cfad68e1fb51efed41c88ce6.

I removed it because the build script was running twice, however this turned out to be due to using the `prepare` npm script, but this has been switched to `prepublishOnly` in 40dc057, so we need the build script here again.