### PR TITLE
Project record type

### DIFF
--- a/examples/schema_test.js
+++ b/examples/schema_test.js
@@ -67,10 +67,10 @@ import { randomBytes } from 'node:crypto'
 // FIELD_1
 const obj = {
   id: randomBytes(32).toString('hex'),
-  schemaType: 'Field',
+  schemaType: 'Project',
   schemaVersion: 1,
-  key: ['hi'],
-  type: 'text',
+  name: 'My Project',
+  created_at: new Date().toJSON(),
 }
 
 // OBSERVATION 4

--- a/proto/project/v1.proto
+++ b/proto/project/v1.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package mapeo;
+
+import "google/protobuf/struct.proto";
+import "common/v1.proto";
+
+message Project_1 {
+  Common_1 common = 1;
+  string name = 2;
+}

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://mapeo.world/schemas/project/v1.json",
+  "title": "Project",
+  "type": "object",
+  "allOf":[{"$ref": "../common/v1.json"}],
+  "properties": {
+    "schemaType": { "type": "string", "pattern": "^Project$" },
+    "schemaVersion": {
+      "type": "number",
+      "minimum": 1,
+      "enum": [1]
+    },
+    "name" : {
+      "description": "name of the project",
+      "type": "string"
+    }
+  },
+  "required": ["schemaType", "schemaVersion", "name"]
+}

--- a/schemasPrefix.js
+++ b/schemasPrefix.js
@@ -7,5 +7,6 @@ const schemasPrefix = {
   coreOwnership: { dataTypeId: '73f85084cb80', schemaVersions: [1] },
   Device: { dataTypeId: '13f85084cb80', schemaVersions: [1] },
   Role: { dataTypeId: '13fa5384cb80', schemaVersions: [1] },
+  Project: { dataTypeId: '13fa5384cb81', schemaVersions: [1] },
 }
 export default schemasPrefix

--- a/test/docs.js
+++ b/test/docs.js
@@ -110,6 +110,13 @@ export const docs = {
       created_at: new Date().toJSON(),
       timestamp: new Date().toJSON(),
     },
+    project: {
+      id: randomBytes(32).toString('hex'),
+      schemaType: 'Project',
+      schemaVersion: 1,
+      created_at: new Date().toJSON(),
+      name: 'My Project',
+    },
   },
 }
 // Object.keys(docs).forEach(save)


### PR DESCRIPTION
This PR adds the `Project` record type. I only added the `name` field, but later we should think about other fields that could be useful. 
This is linked to [this issue](https://github.com/digidem/mapeo-schema/issues/46), it can close it when merge it (and we should create another issue to track work on the `Project` record type) or we can keep it open