### PR TITLE
feat: field v2 using key as always an array of strings

### DIFF
--- a/examples/schema_test.js
+++ b/examples/schema_test.js
@@ -69,6 +69,7 @@ const obj = {
   id: randomBytes(32).toString('hex'),
   schemaType: 'Field',
   schemaVersion: 1,
+  created_at: new Date().toJSON(),
   key: ['hi'],
   type: 'text',
 }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,14 @@ const jsonSchemaToProto = (obj) => {
   common.timestamp = new Date(common.timestamp)
 
   const key = formatSchemaKey(obj.schemaType, obj.schemaVersion)
+
+  // Field_1 can be a string or an array of string
+  // Field_2 is always an array of strings.
+  // So to mantain compatibility, if key is a string we wrap it in an Array
+  if (key === 'Field_1' && uncommon.key && typeof uncommon.key === 'string') {
+    uncommon.key = [uncommon.key]
+  }
+
   // when we inherit from common, common is actually a field inside the protobuf object,
   // so we don't destructure it
   return inheritsFromCommon(key)

--- a/proto/field/v2.proto
+++ b/proto/field/v2.proto
@@ -2,9 +2,10 @@ syntax = "proto3";
 package mapeo;
 
 import "google/protobuf/any.proto";
+import "common/v1.proto";
 
-message Field_1 {
-  bytes id = 1;
+message Field_2 {
+  Common_1 common = 1;
   repeated string key = 2;
   string type = 3;
 }

--- a/schema/field/v2.json
+++ b/schema/field/v2.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://mapeo.world/schemas/field/v1.json",
+  "title": "Field",
+  "description": "A field defines a form field that will be shown to the user when creating or editing a map entity. Presets define which fields are shown to the user for a particular map entity. The field definition defines whether the field should show as a text box, multiple choice, single-select, etc. It defines what tag-value is set when the field is entered.",
+  "type": "object",
+  "allOf":[{"$ref": "../common/v1.json"}],
+  "properties": {
+    "schemaType": {
+      "description": "Must be `Field`",
+      "type": "string",
+      "pattern":"^Field$"
+    },
+    "schemaVersion":{
+      "type": "number",
+      "minimum": 2,
+      "enum":[2]
+    },
+    "key": {
+      "description": "The key in a tags object that this field applies to. Should be a list of strings ",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "type": {
+      "description": "Type of field - defines how the field is displayed to the user.",
+      "type": "string",
+      "meta:enum": {
+        "text": "Freeform text field",
+        "localized": "Text field with localization abilities (e.g. name=*, name:es=*, etc.). Currently only supported in Mapeo Desktop territory view.",
+        "number": "Allows only numbers",
+        "select_one": "Select one item from a list of pre-defined options",
+        "select_multiple": "Select any number of items from a list of pre-defined options",
+        "date": "Select a date",
+        "datetime": "Select a date and time"
+      },
+      "enum": [
+        "text",
+        "localized",
+        "number",
+        "select_one",
+        "select_multiple",
+        "date",
+        "datetime"
+      ]
+    },
+    "label": {
+      "description": "Default language label for the form field label",
+      "type": "string"
+    },
+    "readonly": {
+      "description": "Field is displayed, but it can't be edited",
+      "type": "boolean",
+      "default": false
+    },
+    "appearance": {
+      "description": "For text fields, display as a single-line or multi-line field",
+      "type": "string",
+      "meta:enum": {
+        "singleline": "Text will be cut-off if more than one line",
+        "multiline": "Text will wrap to multiple lines within text field"
+      },
+      "enum": ["singleline", "multiline"],
+      "default": "multiline"
+    },
+    "snake_case": {
+      "description": "Convert field value into snake_case (replace spaces with underscores and convert to lowercase)",
+      "type": "boolean",
+      "default": false
+    },
+    "options": {
+      "description": "List of options the user can select for single- or multi-select fields",
+      "type": "array",
+      "items": {
+        "anyOf": [{
+          "type": "string"
+        }, {
+          "type": "boolean"
+        }, {
+          "type": "number"
+        }, {
+          "type": "null"
+        }, {
+          "type": "object",
+          "properties": {
+            "label": {
+              "description": "Label in default language to display to the user for this option",
+              "type": "string"
+            },
+            "value": {
+              "description": "Value for tag when this option is selected",
+              "anyOf": [{
+                "type": "string"
+              }, {
+                "type": "boolean"
+              }, {
+                "type": "number"
+              }, {
+                "type": "null"
+              }]
+            }
+          },
+          "required": ["value"]
+        }]
+      }
+    },
+    "universal": {
+      "description": "If true, this field will appear in the Add Field list for all presets",
+      "type": "boolean",
+      "default": false
+    },
+    "placeholder": {
+      "description": "Displayed as a placeholder in an empty text or number field before the user begins typing. Use 'helperText' for important information, because the placeholder is not visible after the user has entered data.",
+      "type": "string"
+    },
+    "helperText": {
+      "description": "Additional context about the field, e.g. hints about how to answer the question.",
+      "type": "string"
+    },
+    "min_value": {
+      "description": "Minimum field value (number, date or datetime fields only). For date or datetime fields, is seconds since unix epoch",
+      "type": "integer"
+    },
+    "max_value": {
+      "description": "Maximum field value (number, date or datetime fields only). For date or datetime fields, is seconds since unix epoch",
+      "type": "integer"
+    }
+  },
+  "required": ["id", "created_at", "schemaType", "schemaVersion", "key", "type"]
+}

--- a/schemasPrefix.js
+++ b/schemasPrefix.js
@@ -3,7 +3,7 @@ const schemasPrefix = {
   observation: { dataTypeId: '70f85084cb94', schemaVersions: [4] },
   Preset: { dataTypeId: '71f85084cb98', schemaVersions: [1] },
   filter: { dataTypeId: '71f85084cb90', schemaVersions: [1] },
-  Field: { dataTypeId: '71f85084cb80', schemaVersions: [1] },
+  Field: { dataTypeId: '71f85084cb80', schemaVersions: [1,2] },
   coreOwnership: { dataTypeId: '73f85084cb80', schemaVersions: [1] },
   Device: { dataTypeId: '13f85084cb80', schemaVersions: [1] },
   Role: { dataTypeId: '13fa5384cb80', schemaVersions: [1] },

--- a/test/docs.js
+++ b/test/docs.js
@@ -67,6 +67,14 @@ export const docs = {
     field: {
       id: randomBytes(32).toString('hex'),
       schemaType: 'Field',
+      schemaVersion: 2,
+      created_at: new Date().toJSON(),
+      key: ['hi'],
+      type: 'text',
+    },
+    field_1: {
+      id: randomBytes(32).toString('hex'),
+      schemaType: 'Field',
       schemaVersion: 1,
       key: 'hi',
       type: 'text',


### PR DESCRIPTION
This PR creates a `field/v2` protobuf and json schema to set the `key` field to be a always an `Array` of  type `string`. 
I took the liberty to modify the `field/v1` protobuf to use `repeated string key` instead of `anyof` (since there's no backwards compatibility to keep here)
This protobuf is exactly the same as `field/v2`, but I keep it to mantain parity with the json schema versioning. 
To take into account the `anyof` of `field/v1` jsonschema I basically check if the key field is a `string` and the record is `Field_1` and wrap the `string` in an `Array`.
Since the return value is always an `Array` of `string` then JSONSchema validation will pass.
This should close [this issue](https://github.com/digidem/mapeo-schema/issues/42)