### PR TITLE
feat: type-safe encode function [3/6]

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -13,5 +13,5 @@ plugins:
       # - useOptionals=none
       - stringEnums=true
       - enumsAsLiterals=true
-      - outputIndex=true
+      # - outputIndex=true
       - oneof=unions

--- a/proto/project/v1.proto
+++ b/proto/project/v1.proto
@@ -13,4 +13,18 @@ message Project_1 {
   Common_1 common = 1;
 
   string name = 5;
+  /*
+  // You can't use an enum as a key in a map in protobufs :(
+  enum DefaultPresetsKey {
+    point = 0;
+    vertex = 1;
+    line = 2;
+    area = 3;
+    relation = 4;
+  };
+  message DefaultPresetsValue {
+    repeated string defaultPresetsValue = 1;
+  };
+  map<DefaultPresetsKey,DefaultPresetsValue> defaultPresetsValue= 6;
+  */
 }

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -54,13 +54,13 @@
     },
     "lat": {
       "description": "latitude of the observation",
-      "type": ["number", "null"],
+      "type": "number",
       "minimum": -90,
       "maximum": 90
     },
     "lon": {
       "description": "longitude of the observation",
-      "type": ["number", "null"],
+      "type": "number",
       "minimum": -180,
       "maximum": 180
     },
@@ -187,6 +187,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["schemaName", "tags"],
+  "required": ["schemaName", "tags", "refs", "attachments"],
   "additionalProperties": false
 }

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -7,6 +7,7 @@
     "position": {
       "description": "Position details",
       "type": "object",
+      "required": ["mocked"],
       "properties": {
         "timestamp": {
           "description": "Timestamp of when the current position was obtained",

--- a/schema/preset/v2.json
+++ b/schema/preset/v2.json
@@ -3,6 +3,47 @@
   "$id": "http://mapeo.world/schemas/preset/v2.json",
   "title": "Preset",
   "description": "Presets define how map entities are displayed to the user. They define the icon used on the map, and the fields / questions shown to the user when they create or edit the entity on the map. The `tags` property of a preset is used to match the preset with observations, nodes, ways and relations. If multiple presets match, the one that matches the most tags is used.",
+  "definitions": {
+    "tags": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
   "type": "object",
   "properties": {
     "schemaName": {
@@ -26,21 +67,15 @@
     },
     "tags": {
       "description": "The tags are used to match the preset to existing map entities. You can match based on multiple tags E.g. if you have existing points with the tags `nature:tree` and `species:oak` then you can add both these tags here in order to match only oak trees.",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": true
+      "$ref": "#/definitions/tags"
     },
     "addTags": {
       "description": "Tags that are added when changing to the preset (default is the same value as 'tags')",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": true
+      "$ref": "#/definitions/tags"
     },
     "removeTags": {
       "description": "Tags that are removed when changing to another preset (default is the same value as 'addTags' which in turn defaults to 'tags')",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": true
+      "$ref": "#/definitions/tags"
     },
     "fields": {
       "description": "hex-encoded string. IDs of fields to displayed to the user when the preset is created or edited",
@@ -61,6 +96,15 @@
       }
     }
   },
-  "required": ["name", "geometry", "tags", "schemaName"],
+  "required": [
+    "name",
+    "geometry",
+    "tags",
+    "addTags",
+    "removeTags",
+    "fields",
+    "schemaName",
+    "terms"
+  ],
   "additionalProperties": false
 }

--- a/schema/preset/v2.json
+++ b/schema/preset/v2.json
@@ -58,7 +58,6 @@
     "geometry": {
       "description": "Valid geometry types for the feature - this preset will only match features of this geometry type `\"point\", \"vertex\", \"line\", \"area\", \"relation\"`",
       "type": "array",
-      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string",
@@ -77,7 +76,7 @@
       "description": "Tags that are removed when changing to another preset (default is the same value as 'addTags' which in turn defaults to 'tags')",
       "$ref": "#/definitions/tags"
     },
-    "fields": {
+    "fieldIds": {
       "description": "hex-encoded string. IDs of fields to displayed to the user when the preset is created or edited",
       "type": "array",
       "items": {
@@ -102,7 +101,7 @@
     "tags",
     "addTags",
     "removeTags",
-    "fields",
+    "fieldIds",
     "schemaName",
     "terms"
   ],

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -12,6 +12,7 @@ import { generateConfig } from './lib/generate-config.js'
 import { readJSONSchema } from './lib/read-json-schema.js'
 import { generateValidations } from './lib/generate-validations.js'
 import { generateJSONSchemaTS } from './lib/generate-jsonschema-ts.js'
+import { generateEncodeDecode } from './lib/generate-encode-decode.js'
 
 const DIST_DIRNAME = path.join(PROJECT_ROOT, 'dist')
 const TYPES_DIRNAME = path.join(PROJECT_ROOT, 'types')
@@ -30,6 +31,12 @@ const protoTypesFile = generateProtoTypes(config)
 fs.writeFileSync(
   path.join(PROJECT_ROOT, 'types/proto/types.ts'),
   protoTypesFile
+)
+
+const encodeDecodeFile = generateEncodeDecode(config)
+fs.writeFileSync(
+  path.join(PROJECT_ROOT, 'types/proto/index.ts'),
+  encodeDecodeFile
 )
 
 const configFile = generateConfig(config)

--- a/scripts/lib/generate-encode-decode.js
+++ b/scripts/lib/generate-encode-decode.js
@@ -1,0 +1,31 @@
+// @ts-check
+/**
+ * @param {ReturnType<import('./parse-config.js').parseConfig>} config
+ */
+export function generateEncodeDecode({ currentSchemaVersions, protoTypeDefs }) {
+  const typeImports = protoTypeDefs.map(
+    ({ schemaName, schemaVersion, typeName }) => {
+      return `import { ${typeName} } from './${schemaName}/v${schemaVersion}'`
+    }
+  )
+
+  const currentProtoTypeDefs = protoTypeDefs.filter(
+    ({ schemaName, schemaVersion }) => {
+      return currentSchemaVersions[schemaName] === schemaVersion
+    }
+  )
+
+  const encodeLines = ['export const Encode = {']
+  for (const { schemaName, typeName } of currentProtoTypeDefs) {
+    encodeLines.push(`  ${schemaName}: ${typeName}.encode,`)
+  }
+  encodeLines.push('}')
+
+  const decodeLines = ['export const Decode = {']
+  for (const { typeName } of protoTypeDefs) {
+    decodeLines.push(`  ${typeName}: ${typeName}.decode,`)
+  }
+  decodeLines.push('}')
+
+  return [...typeImports, '', ...encodeLines, '', ...decodeLines, ''].join('\n')
+}

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -5,6 +5,10 @@ export function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
+export function getTypeName(schemaName, schemaVersion) {
+  return capitalize(schemaName) + '_' + schemaVersion
+}
+
 export const PROJECT_ROOT = path.resolve(
   path.dirname(new URL(import.meta.url).pathname),
   '../..'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+/** Length in bytes of data type ID encoding */
+export const DATA_TYPE_ID_BYTES = 6
+/** Length in bytes of schema version encoding */
+export const SCHEMA_VERSION_BYTES = 2

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,4 +1,4 @@
-import { type ProtoTypeNames, ProtoTypes } from '../types/proto/types'
+import { ProtoTypes } from '../types/proto/types'
 import {
   type JsonSchemaTypes,
   type ProtoTypesWithSchemaInfo,
@@ -17,9 +17,8 @@ import {
 } from './lib/decode-conversions'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
-
-const dataTypeIdSize = 6
-const schemaVersionSize = 2
+import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants'
+import { getProtoTypeName } from './lib/utils'
 
 /** Map of dataTypeIds to schema names for quick lookups */
 const dataTypeIdToSchemaName: Record<string, SchemaName> = {}
@@ -39,7 +38,7 @@ export function decode(buf: Buffer, versionObj: VersionObj): JsonSchemaTypes {
   const schemaDef = decodeBlockPrefix(buf)
 
   const encodedMsg = buf.subarray(
-    dataTypeIdSize + schemaVersionSize,
+    DATA_TYPE_ID_BYTES + SCHEMA_VERSION_BYTES,
     buf.length
   )
 
@@ -67,21 +66,21 @@ export function decode(buf: Buffer, versionObj: VersionObj): JsonSchemaTypes {
  * Will throw if dataTypeId and schema version is unknown
  */
 export function decodeBlockPrefix(buf: Buffer): ValidSchemaDef {
-  if (buf.length < dataTypeIdSize + schemaVersionSize) {
+  if (buf.length < DATA_TYPE_ID_BYTES + SCHEMA_VERSION_BYTES) {
     throw new Error('Invalid block prefix - unexpected prefix length')
   }
   const state = cenc.state()
   state.buffer = buf
   state.start = 0
-  state.end = dataTypeIdSize
-  const dataTypeId = cenc.hex.fixed(dataTypeIdSize).decode(state)
+  state.end = DATA_TYPE_ID_BYTES
+  const dataTypeId = cenc.hex.fixed(DATA_TYPE_ID_BYTES).decode(state)
 
   if (typeof dataTypeId !== 'string') {
     throw new Error('Invalid block prefix, could not decode dataTypeId')
   }
 
-  state.start = dataTypeIdSize
-  state.end = dataTypeIdSize + schemaVersionSize
+  state.start = DATA_TYPE_ID_BYTES
+  state.end = DATA_TYPE_ID_BYTES + SCHEMA_VERSION_BYTES
   const schemaVersion = cenc.uint16.decode(state)
 
   if (typeof schemaVersion !== 'number') {
@@ -129,20 +128,6 @@ function assertKnownSchemaDef(schemaDef: {
       `Unknown schema version '${schemaVersion}' for schema '${schemaName}'`
     )
   }
-}
-
-/**
- * Get the name of the type, e.g. `Observation_5` for schemaName `observation`
- * and schemaVersion `1`
- */
-function getProtoTypeName(schemaDef: ValidSchemaDef): ProtoTypeNames {
-  return (capitalize(schemaDef.schemaName) +
-    '_' +
-    schemaDef.schemaVersion) as ProtoTypeNames
-}
-
-function capitalize<T extends string>(str: T): Capitalize<T> {
-  return (str.charAt(0).toUpperCase() + str.slice(1)) as any
 }
 
 // function mutatingOmit<T, K extends keyof any>(obj: T, key: K): OmitUnion<T, K> {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -8,7 +8,7 @@ import {
   type ValidSchemaDef,
 } from './types'
 
-import * as ProtobufEncodeDecode from '../types/proto/index.mapeo'
+import { Decode } from '../types/proto/index'
 import { dataTypeIds, knownSchemaVersions } from '../config'
 import {
   convertProject,
@@ -42,10 +42,10 @@ export function decode(buf: Buffer, versionObj: VersionObj): JsonSchemaTypes {
     buf.length
   )
 
-  const messageWithSchemaInfo =
-    ProtobufEncodeDecode[getProtoTypeName(schemaDef)].decode(encodedMsg)
+  const messageWithoutSchemaInfo =
+    Decode[getProtoTypeName(schemaDef)](encodedMsg)
 
-  const message = mutatingSetSchemaDef(messageWithSchemaInfo, schemaDef)
+  const message = mutatingSetSchemaDef(messageWithoutSchemaInfo, schemaDef)
 
   switch (message.schemaName) {
     case 'project':

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -14,6 +14,7 @@ import {
   convertProject,
   convertField,
   convertObservation,
+  convertPreset,
 } from './lib/decode-conversions'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
@@ -54,6 +55,8 @@ export function decode(buf: Buffer, versionObj: VersionObj): JsonSchemaTypes {
       return convertObservation(message, versionObj)
     case 'field':
       return convertField(message, versionObj)
+    case 'preset':
+      return convertPreset(message, versionObj)
     default:
       const _exhaustiveCheck: never = message
       return message

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -7,6 +7,7 @@ import { Encode } from '../types/proto/index'
 import {
   convertField,
   convertObservation,
+  convertPreset,
   convertProject,
 } from './lib/encode-converstions'
 
@@ -37,6 +38,11 @@ export function encode(mapeoDoc: JsonSchemaTypes): Buffer {
     }
     case 'project': {
       const message = convertProject(mapeoDoc)
+      protobuf = Encode[mapeoDoc.schemaName](message).finish()
+      break
+    }
+    case 'preset': {
+      const message = convertPreset(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,0 +1,79 @@
+import { JsonSchemaTypes, SchemaName, ValidSchemaDef } from './types'
+import { currentSchemaVersions, dataTypeIds } from '../config'
+// @ts-ignore
+import * as cenc from 'compact-encoding'
+import { DATA_TYPE_ID_BYTES } from './constants'
+import { getProtoTypeName } from './lib/utils'
+import * as ProtobufEncodeDecode from '../types/proto/index.mapeo'
+
+/**
+ * Encode a an object validated against a schema as a binary protobuf prefixed
+ * with the encoded data type ID and schema version, to send to an hypercore.
+ */
+export function encode(mapeoDoc: JsonSchemaTypes): Buffer {
+  const { schemaName } = mapeoDoc
+  const schemaVersion = currentSchemaVersions[schemaName]
+  const schemaDef = { schemaName, schemaVersion }
+  assertCurrentSchemaDef(schemaDef)
+
+  const protoTypeName = getProtoTypeName(schemaDef)
+
+  // check if protoTypeName is valid
+  if (!ProtobufEncodeDecode[protoTypeName]) {
+    throw new Error(
+      `Unexpected type: schemaName: '${schemaName}', schemaVersion: ${schemaVersion}`
+    )
+  }
+
+  const blockPrefix = encodeBlockPrefix(schemaDef)
+
+  let protobuf: Buffer
+
+  switch (mapeoDoc.schemaName) {
+    case 'field':
+      protobuf = Buffer.alloc(0)
+      break
+    case 'observation':
+      protobuf = Buffer.alloc(0)
+      break
+    case 'project':
+      protobuf = Buffer.alloc(0)
+      break
+    default:
+      const _exhaustiveCheck: never = mapeoDoc
+      protobuf = Buffer.alloc(0)
+  }
+
+  return Buffer.concat([blockPrefix, protobuf])
+}
+
+/**
+ * @private - exported for unit tests
+ * Encode schemaVersion and schemaName to a Buffer (schemaName replaced with corresponding dataTypeId)
+ */
+export function encodeBlockPrefix({
+  schemaName,
+  schemaVersion,
+}: ValidSchemaDef): Buffer {
+  const dataTypeId = dataTypeIds[schemaName]
+  return Buffer.concat([
+    cenc.encode(cenc.hex.fixed(DATA_TYPE_ID_BYTES), dataTypeId),
+    cenc.encode(cenc.uint16, schemaVersion),
+  ])
+}
+
+/**
+ * Assert that a given schemaName and schemaVersion is "current", e.g. does it
+ * match the current JSONSchema types that we know how to deal with?
+ */
+function assertCurrentSchemaDef(schemaDef: {
+  schemaName: SchemaName
+  schemaVersion: number
+}): asserts schemaDef is ValidSchemaDef {
+  const { schemaName, schemaVersion } = schemaDef
+  if (schemaVersion !== currentSchemaVersions[schemaName]) {
+    throw new Error(
+      `Invalid schema version '${schemaVersion}' for schema '${schemaName}'`
+    )
+  }
+}

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -10,22 +10,10 @@ import {
   type VersionObj,
   type SchemaName,
   type FilterBySchemaName,
+  type JsonSchemaCommon,
+  type TagValuePrimitive,
+  type JsonTagValue,
 } from '../types'
-
-/** The `tags` field supports only a subset of JSON values - we don't support nested tags, just primitives or arrays of primitives */
-type TagValuePrimitive = number | string | boolean | null | undefined
-type JsonTagValue =
-  | TagValuePrimitive
-  | Array<Exclude<TagValuePrimitive, undefined>>
-
-/** Just the common (shared) props from JSON schema types */
-type JsonSchemaCommon = Pick<JsonSchemaTypes, ProtoTypeCommonKeys | 'version'>
-
-/** Union of keys from the common prop on Proto types */
-type ProtoTypeCommonKeys = keyof Exclude<
-  ProtoTypesWithSchemaInfo['common'],
-  undefined
->
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -4,6 +4,7 @@ import {
   type TagValue_1,
   type TagValue_1_PrimitiveValue,
 } from '../../types/proto/tags/v1'
+import { Preset } from '../../types/schema'
 import {
   type JsonSchemaTypes,
   type ProtoTypesWithSchemaInfo,
@@ -83,6 +84,33 @@ export const convertField: ConvertFunction<'field'> = (message, versionObj) => {
         []
       ),
     }
+  }
+}
+
+type JsonSchemaPresetGeomItem = FilterBySchemaName<
+  JsonSchemaTypes,
+  'preset'
+>['geometry'][number]
+
+export const convertPreset: ConvertFunction<'preset'> = (
+  message,
+  versionObj
+) => {
+  const { common, schemaVersion, ...rest } = message
+  const jsonSchemaCommon = convertCommon(common, versionObj)
+  const geometry = rest.geometry.filter(
+    (geomType): geomType is JsonSchemaPresetGeomItem =>
+      geomType !== 'UNRECOGNIZED'
+  )
+
+  return {
+    ...jsonSchemaCommon,
+    ...rest,
+    geometry,
+    tags: convertTags(rest.tags),
+    addTags: convertTags(rest.addTags),
+    removeTags: convertTags(rest.removeTags),
+    fieldIds: rest.fieldIds.map((id) => id.toString('hex')),
   }
 }
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -1,14 +1,24 @@
 import { CurrentProtoTypes } from '../../types/proto/types'
-import { JsonSchemaTypes, SchemaName } from '../types'
+import {
+  JsonSchemaTypes,
+  ProtoTypesWithSchemaInfo,
+  SchemaName,
+  JsonSchemaCommon,
+  TagValuePrimitive,
+  JsonTagValue,
+} from '../types'
 import { hexStringToCoreVersion } from '../../utils'
-import { TagValue_1_ListValue } from '../../types/proto/tags/v1'
+import {
+  TagValue_1,
+  type TagValue_1_ListValue,
+  type TagValue_1_PrimitiveValue,
+} from '../../types/proto/tags/v1'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
 type ConvertFunction<TSchemaName extends SchemaName> = (
   mapeoDoc: Extract<JsonSchemaTypes, { schemaName: TSchemaName }>
 ) => CurrentProtoTypes[TSchemaName]
-
 
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
   return mapeoDoc as any
@@ -22,25 +32,91 @@ export const convertObservation: ConvertFunction<'observation'> = (
   // I can name this return with a variable of type of
   // CurrentProtoTypes['observation']
   return {
-    common: {
-      id:Buffer.from(mapeoDoc.id,'hex'),
-      createdAt:mapeoDoc.createdAt,
-      updatedAt: mapeoDoc.updatedAt,
-      links: mapeoDoc.links.map(hexStringToCoreVersion)
-    },
-    refs:mapeoDoc.refs
-      ? mapeoDoc.refs.map((ref) => { return {id: Buffer.from(ref.id, 'hex')}})
+    common: convertCommon(mapeoDoc),
+    refs: mapeoDoc.refs
+      ? mapeoDoc.refs.map((ref) => {
+          return { id: Buffer.from(ref.id, 'hex') }
+        })
       : [],
     attachments: mapeoDoc.attachments
-    ? mapeoDoc.attachments.map((attachment) => {
-      return {
-        driveId: Buffer.from(attachment.driveId, 'hex'),
-        name: attachment.name,
-        type: attachment.type
-      }
-    })
-    : [],
-    tags: {}
+      ? mapeoDoc.attachments.map((attachment) => {
+          return {
+            driveId: Buffer.from(attachment.driveId, 'hex'),
+            name: attachment.name,
+            type: attachment.type,
+          }
+        })
+      : [],
+    tags: {},
     // tags: Object.keys(mapeoDoc.tags).map(k => { })
   }
+}
+
+function convertCommon(
+  common: JsonSchemaCommon
+): ProtoTypesWithSchemaInfo['common'] {
+  return {
+    id: Buffer.from(common.id, 'hex'),
+    createdAt: common.createdAt,
+    updatedAt: common.updatedAt,
+    links: common.links.map(hexStringToCoreVersion),
+  }
+}
+
+function convertTagValue(tagValue: JsonTagValue): TagValue_1 {
+  let kind: TagValue_1['kind']
+  if (Array.isArray(tagValue)) {
+    kind = {
+      $case: 'list_value',
+      list_value: {
+        list_value: tagValue
+          .filter((v) => typeof v !== 'undefined')
+          .map((v) => convertTagPrimitive(v)),
+      },
+    }
+  } else {
+    kind = {
+      $case: 'primitive_value',
+      primitive_value: convertTagPrimitive(tagValue),
+    }
+  }
+  return { kind }
+}
+
+function convertTagPrimitive(
+  tagPrimitive: TagValuePrimitive
+): TagValue_1_PrimitiveValue {
+  let kind: TagValue_1_PrimitiveValue['kind']
+  switch (typeof tagPrimitive) {
+    case 'boolean':
+      kind = {
+        $case: 'boolean_value',
+        boolean_value: tagPrimitive,
+      }
+      break
+    case 'string':
+      kind = {
+        $case: 'string_value',
+        string_value: tagPrimitive,
+      }
+      break
+    case 'number':
+      kind = {
+        $case: 'number_value',
+        number_value: tagPrimitive,
+      }
+      break
+    case 'undefined':
+      kind = undefined
+      break
+    case 'object': // null
+      kind = {
+        $case: 'null_value',
+        null_value: 'NULL_VALUE',
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = tagPrimitive
+  }
+  return { kind }
 }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -44,6 +44,24 @@ export const convertField: ConvertFunction<'field'> = (mapeoDoc) => {
 
   }
 }
+
+// export const convertPreset: ConvertFunction<'preset'> = (mapeoDoc) => {
+//   return {
+//     common: convertCommon(mapeoDoc),
+//     name: mapeoDoc.name,
+//     geometry: mapeoDoc.geometry,
+//     tags: convertTags(mapeoDoc.tags),
+//     addTags: mapeoDoc.addTags ? convertTags(mapeoDoc.addTags) : {},
+//     removeTags: mapeoDoc.removeTags ? convertTags(mapeoDoc.removeTags) : {},
+//     fieldIds: mapeoDoc.fields
+//       ? mapeoDoc.fields.map((field) => Buffer.from(field,'hex'))
+//       : [],
+//     iconId: mapeoDoc.icon ? Buffer.from(mapeoDoc.icon,'hex') : undefined,
+//     terms: mapeoDoc.terms ? mapeoDoc.terms : []
+
+//   }
+// }
+
 export const convertObservation: ConvertFunction<'observation'> = (
   mapeoDoc
 ) => {

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -1,11 +1,14 @@
 import { CurrentProtoTypes } from '../../types/proto/types'
 import { JsonSchemaTypes, SchemaName } from '../types'
+import { hexStringToCoreVersion } from '../../utils'
+import { TagValue_1_ListValue } from '../../types/proto/tags/v1'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
 type ConvertFunction<TSchemaName extends SchemaName> = (
   mapeoDoc: Extract<JsonSchemaTypes, { schemaName: TSchemaName }>
 ) => CurrentProtoTypes[TSchemaName]
+
 
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
   return mapeoDoc as any
@@ -16,5 +19,28 @@ export const convertField: ConvertFunction<'field'> = (mapeoDoc) => {
 export const convertObservation: ConvertFunction<'observation'> = (
   mapeoDoc
 ) => {
-  return mapeoDoc as any
+  // I can name this return with a variable of type of
+  // CurrentProtoTypes['observation']
+  return {
+    common: {
+      id:Buffer.from(mapeoDoc.id,'hex'),
+      createdAt:mapeoDoc.createdAt,
+      updatedAt: mapeoDoc.updatedAt,
+      links: mapeoDoc.links.map(hexStringToCoreVersion)
+    },
+    refs:mapeoDoc.refs
+      ? mapeoDoc.refs.map((ref) => { return {id: Buffer.from(ref.id, 'hex')}})
+      : [],
+    attachments: mapeoDoc.attachments
+    ? mapeoDoc.attachments.map((attachment) => {
+      return {
+        driveId: Buffer.from(attachment.driveId, 'hex'),
+        name: attachment.name,
+        type: attachment.type
+      }
+    })
+    : [],
+    tags: {}
+    // tags: Object.keys(mapeoDoc.tags).map(k => { })
+  }
 }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -13,6 +13,7 @@ import {
   type TagValue_1_ListValue,
   type TagValue_1_PrimitiveValue,
 } from '../../types/proto/tags/v1'
+import { Observation_5_Metadata } from '../../types/proto/observation/v5'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
@@ -55,7 +56,7 @@ export const convertPreset: ConvertFunction<'preset'> = (mapeoDoc) => {
     tags: convertTags(mapeoDoc.tags),
     addTags: convertTags(mapeoDoc.addTags),
     removeTags: convertTags(mapeoDoc.removeTags),
-    fieldIds: mapeoDoc.fields.map((field) => Buffer.from(field, 'hex')),
+    fieldIds: mapeoDoc.fieldIds.map((field) => Buffer.from(field, 'hex')),
     iconId: mapeoDoc.icon ? Buffer.from(mapeoDoc.icon, 'hex') : undefined,
   }
 }
@@ -80,6 +81,9 @@ export const convertObservation: ConvertFunction<'observation'> = (
     refs,
     attachments,
     tags: convertTags(mapeoDoc.tags),
+    metadata:
+      mapeoDoc.metadata &&
+      Observation_5_Metadata.fromPartial(mapeoDoc.metadata),
   }
 }
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -1,0 +1,20 @@
+import { CurrentProtoTypes } from '../../types/proto/types'
+import { JsonSchemaTypes, SchemaName } from '../types'
+
+/** Function type for converting a protobuf type of any version for a particular
+ * schema name, and returning the most recent JSONSchema type */
+type ConvertFunction<TSchemaName extends SchemaName> = (
+  mapeoDoc: Extract<JsonSchemaTypes, { schemaName: TSchemaName }>
+) => CurrentProtoTypes[TSchemaName]
+
+export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
+  return mapeoDoc as any
+}
+export const convertField: ConvertFunction<'field'> = (mapeoDoc) => {
+  return mapeoDoc as any
+}
+export const convertObservation: ConvertFunction<'observation'> = (
+  mapeoDoc
+) => {
+  return mapeoDoc as any
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,16 @@
+import { type ProtoTypeNames } from '../../types/proto/types'
+import { type ValidSchemaDef } from '../types'
+
+/**
+ * Get the name of the type, e.g. `Observation_5` for schemaName `observation`
+ * and schemaVersion `1`
+ */
+export function getProtoTypeName(schemaDef: ValidSchemaDef): ProtoTypeNames {
+  return (capitalize(schemaDef.schemaName) +
+    '_' +
+    schemaDef.schemaVersion) as ProtoTypeNames
+}
+
+function capitalize<T extends string>(str: T): Capitalize<T> {
+  return (str.charAt(0).toUpperCase() + str.slice(1)) as any
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,24 @@ export type ValidSchemaDef = PickUnion<
   'schemaName' | 'schemaVersion'
 >
 
+/** The `tags` field supports only a subset of JSON values - we don't support nested tags, just primitives or arrays of primitives */
+export type TagValuePrimitive = number | string | boolean | null | undefined
+export type JsonTagValue =
+  | TagValuePrimitive
+  | Array<Exclude<TagValuePrimitive, undefined>>
+
+/** Union of keys from the common prop on Proto types */
+type ProtoTypeCommonKeys = keyof Exclude<
+  ProtoTypesWithSchemaInfo['common'],
+  undefined
+>
+
+/** Just the common (shared) props from JSON schema types */
+export type JsonSchemaCommon = Pick<
+  JsonSchemaTypes,
+  ProtoTypeCommonKeys | 'version'
+>
+
 /** Filter a union of objects to only include those that have a prop `schemaName` that matches U */
 export type FilterBySchemaName<
   T extends { schemaName: string },

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import { type JsonSchemaTypes as AllJsonSchemaTypes } from '../types/schema'
 import { dataTypeIds } from '../config'
 
 /** Temporary: once we have completed this module everything should be supported */
-type SupportedSchemaNames = 'project' | 'observation' | 'field'
+type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset'
 
 export type SchemaName = Extract<keyof typeof dataTypeIds, SupportedSchemaNames>
 


### PR DESCRIPTION
### Todo (type conversions)

- [x] Field
- [x] Observation
- [x] Project
- [x] Preset

`Role`, `Device`, `CoreOwnership` to be tackled in follow-up PR once those schemas are finalized.