### PR TITLE
fix: Change prop names and type names [5/6]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapeo/schema",
-  "version": "3.0.0-next.3",
+  "version": "3.0.0-next.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapeo/schema",
-      "version": "3.0.0-next.3",
+      "version": "3.0.0-next.4",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.25.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapeo/schema",
-  "version": "3.0.0-next.3",
+  "version": "3.0.0-next.4",
   "description": "JSON schema and flow types for Mapeo",
   "main": "dist/index.js",
   "type": "module",

--- a/proto/common/v1.proto
+++ b/proto/common/v1.proto
@@ -6,7 +6,7 @@ import "options.proto";
 
 message Common_1 {
   // 32-byte random generated number
-  optional bytes id = 1 [(required) = true];
+  optional bytes docId = 1 [(required) = true];
   message Link {
     bytes coreId = 1;
     int32 seq = 2;

--- a/schema/common/v1.json
+++ b/schema/common/v1.json
@@ -13,6 +13,10 @@
       "description": "id (hex-encoded 32-byte buffer) and core sequence number, separated by '/'",
       "type": "string"
     },
+    "schemaName": {
+      "description": "Name of Mapeo data type / schema",
+      "type": "string"
+    },
     "createdAt": {
       "description": "RFC3339-formatted datetime of when the first version of the element was created",
       "type": "string",
@@ -32,5 +36,12 @@
       }
     }
   },
-  "required": ["docId", "createdAt", "updatedAt", "links", "versionId"]
+  "required": [
+    "docId",
+    "createdAt",
+    "schemaName",
+    "updatedAt",
+    "links",
+    "versionId"
+  ]
 }

--- a/schema/common/v1.json
+++ b/schema/common/v1.json
@@ -5,11 +5,11 @@
   "description": "These properties are shared by all objects in the Mapeo database.",
   "type": "object",
   "properties": {
-    "id": {
+    "docId": {
       "description": "Hex-encoded 32-byte buffer",
       "type": "string"
     },
-    "version": {
+    "versionId": {
       "description": "id (hex-encoded 32-byte buffer) and core sequence number, separated by '/'",
       "type": "string"
     },
@@ -32,5 +32,5 @@
       }
     }
   },
-  "required": ["id", "createdAt", "updatedAt", "links", "version"]
+  "required": ["docId", "createdAt", "updatedAt", "links", "versionId"]
 }

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -155,12 +155,10 @@
           "default": false
         },
         "position": {
-          "$ref": "#/definitions/position",
-          "description": "Details of the position recorded for the observation"
+          "$ref": "#/definitions/position"
         },
         "lastSavedPosition": {
-          "$ref": "#/definitions/position",
-          "description": "Details of the last saved position when the observation was recorded - useful if position is not recorded"
+          "$ref": "#/definitions/position"
         },
         "positionProvider": {
           "description": "Details of the location providers that were available on the device when the observation was recorded",

--- a/scripts/lib/generate-jsonschema-ts.js
+++ b/scripts/lib/generate-jsonschema-ts.js
@@ -5,13 +5,13 @@ import { capitalize } from './utils.js'
 /**
  * Returns generated typescript definitions for JSONSchemas
  *
- * @param {ReturnType<import('./parse-config').parseConfig>} config
- * @param {Record<string, import('json-schema').JSONSchema7>} jsonSchemas
+ * @param {ReturnType<import('./parse-config.js').parseConfig>} config
+ * @param {ReturnType<import('./read-json-schema.js').readJSONSchema>} jsonSchemas
  */
 export async function generateJSONSchemaTS(config, jsonSchemas) {
   /** @type {Record<string, string>} */
   const typescriptDefs = {}
-  for (const [schemaName, jsonSchema] of Object.entries(jsonSchemas)) {
+  for (const [schemaName, jsonSchema] of Object.entries(jsonSchemas.values)) {
     // @ts-ignore
     const ts = await compile(jsonSchema, capitalize(schemaName), {
       additionalProperties: false,
@@ -22,27 +22,56 @@ export async function generateJSONSchemaTS(config, jsonSchemas) {
 
   const indexLines = []
 
-  for (const schemaName of Object.keys(jsonSchemas)) {
+  for (const schemaName of Object.keys(jsonSchemas.values)) {
     const typeName = capitalize(schemaName)
-    indexLines.push(`import { type ${typeName} } from './${schemaName}.js'`)
+    const valueName = getValueName(schemaName)
+
+    indexLines.push(
+      `import { type ${typeName} as ${valueName} } from './${schemaName}.js'`
+    )
   }
 
-  indexLines.push('')
-  indexLines.push('export type JsonSchemaTypes = ')
+  indexLines.push(
+    '',
+    'type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};',
+    ''
+  )
 
-  for (const schemaName of Object.keys(jsonSchemas)) {
+  for (const [schemaName, schema] of Object.entries(jsonSchemas.values)) {
+    if (schemaName === 'common') continue
+    const typeName = capitalize(schemaName)
+    const valueName = getValueName(schemaName)
+    if (schema.description) {
+      indexLines.push(`/** ${schema.description} */`)
+    }
+    indexLines.push(
+      `export type ${typeName} = Simplify<${valueName} & MapeoCommon>`
+    )
+  }
+
+  indexLines.push('', 'export type MapeoDoc = ')
+
+  for (const schemaName of Object.keys(jsonSchemas.values)) {
+    if (schemaName === 'common') continue
     const typeName = capitalize(schemaName)
     indexLines.push(` |  ${typeName}`)
   }
 
   indexLines.push('')
 
-  for (const schemaName of Object.keys(jsonSchemas)) {
-    const typeName = capitalize(schemaName)
+  for (const schemaName of Object.keys(jsonSchemas.values)) {
+    const typeName = getValueName(schemaName)
     indexLines.push(`export { ${typeName} }`)
   }
 
   typescriptDefs.index = indexLines.join('\n') + '\n'
 
   return typescriptDefs
+}
+
+/** @param {string} schemaName */
+function getValueName(schemaName) {
+  return schemaName === 'common'
+    ? 'MapeoCommon'
+    : capitalize(schemaName) + 'Value'
 }

--- a/scripts/lib/generate-validations.js
+++ b/scripts/lib/generate-validations.js
@@ -5,16 +5,17 @@ import standaloneCode from 'ajv/dist/standalone/index.js'
 /**
  * Returns generated code for validation functions
  *
- * @param {ReturnType<import('./parse-config').parseConfig>} config
- * @param {Record<string, import('json-schema').JSONSchema7>} jsonSchemas
+ * @param {ReturnType<import('./parse-config.js').parseConfig>} config
+ * @param {ReturnType<import('./read-json-schema.js').readJSONSchema>} jsonSchemas
  */
 export function generateValidations(config, jsonSchemas) {
-  const schemas = Object.entries(jsonSchemas)
+  const schemas = Object.entries(jsonSchemas.values)
 
   const schemaExports = schemas.reduce((acc, [schemaName, jsonSchema]) => {
+    if (!jsonSchema['$id']) throw new Error(`Missing $id prop on ${schemaName}`)
     acc[schemaName] = jsonSchema['$id']
     return acc
-  }, {})
+  }, /** @type {Record<string, string>} */ ({}))
 
   // compile schemas
   const ajv = new Ajv({

--- a/scripts/lib/read-json-schema.js
+++ b/scripts/lib/read-json-schema.js
@@ -24,6 +24,7 @@ export function readJSONSchema({ currentSchemaVersions }) {
   })
 
   const common = readJSON('./schema/common/v1.json')
+  common.properties.schemaName.enum = []
 
   const jsonSchemaDefs = jsonSchemaFiles.map((filepath) => {
     /** @type {import('json-schema').JSONSchema7} */
@@ -53,6 +54,7 @@ export function readJSONSchema({ currentSchemaVersions }) {
 
   for (const { schemaName, schemaVersion, jsonSchema } of jsonSchemaDefs) {
     if (schemaVersion !== currentSchemaVersions[schemaName]) continue
+    common.properties.schemaName.enum.push(schemaName)
     values[schemaName] = jsonSchema
     merged[schemaName] = mergeCommon(jsonSchema, common)
   }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,6 +1,6 @@
 import { ProtoTypes } from './proto/types.js'
 import {
-  type JsonSchemaTypes,
+  type MapeoDoc,
   type ProtoTypesWithSchemaInfo,
   type VersionObj,
   type SchemaName,
@@ -35,7 +35,7 @@ for (const [schemaName, dataTypeId] of Object.entries(dataTypeIds) as Array<
  * @param buf Buffer to be decoded
  * @param versionObj public key (coreId) of the core where this block is stored, and the index (seq) of the block in the core.
  * */
-export function decode(buf: Buffer, versionObj: VersionObj): JsonSchemaTypes {
+export function decode(buf: Buffer, versionObj: VersionObj): MapeoDoc {
   const schemaDef = decodeBlockPrefix(buf)
 
   const encodedMsg = buf.subarray(

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,9 +1,4 @@
-import {
-  JsonSchemaTypes,
-  OmitUnion,
-  SchemaName,
-  ValidSchemaDef,
-} from './types.js'
+import { MapeoDoc, OmitUnion, SchemaName, ValidSchemaDef } from './types.js'
 import { currentSchemaVersions, dataTypeIds } from './config.js'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
@@ -20,9 +15,7 @@ import {
  * Encode a an object validated against a schema as a binary protobuf prefixed
  * with the encoded data type ID and schema version, to send to an hypercore.
  */
-export function encode(
-  mapeoDoc: OmitUnion<JsonSchemaTypes, 'version'>
-): Buffer {
+export function encode(mapeoDoc: OmitUnion<MapeoDoc, 'version'>): Buffer {
   const { schemaName } = mapeoDoc
   const schemaVersion = currentSchemaVersions[schemaName]
   const schemaDef = { schemaName, schemaVersion }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -172,7 +172,7 @@ function convertTagPrimitive({
 function convertCommon(
   common: ProtoTypesWithSchemaInfo['common'],
   versionObj: VersionObj
-): MapeoCommon {
+): Omit<MapeoCommon, 'schemaName'> {
   if (!common || !common.docId || !common.createdAt || !common.updatedAt) {
     throw new Error('Missing required common properties')
   }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -173,13 +173,13 @@ function convertCommon(
   common: ProtoTypesWithSchemaInfo['common'],
   versionObj: VersionObj
 ): JsonSchemaCommon {
-  if (!common || !common.id || !common.createdAt || !common.updatedAt) {
+  if (!common || !common.docId || !common.createdAt || !common.updatedAt) {
     throw new Error('Missing required common properties')
   }
 
   return {
-    id: common.id.toString('hex'),
-    version: versionObjToString(versionObj),
+    docId: common.docId.toString('hex'),
+    versionId: versionObjToString(versionObj),
     links: common.links.map(versionObjToString),
     createdAt: common.createdAt,
     updatedAt: common.updatedAt,

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -5,12 +5,12 @@ import {
   type TagValue_1_PrimitiveValue,
 } from '../proto/tags/v1.js'
 import {
-  type JsonSchemaTypes,
+  type MapeoDoc,
   type ProtoTypesWithSchemaInfo,
   type VersionObj,
   type SchemaName,
   type FilterBySchemaName,
-  type JsonSchemaCommon,
+  type MapeoCommon,
   type TagValuePrimitive,
   type JsonTagValue,
 } from '../types.js'
@@ -20,7 +20,7 @@ import {
 type ConvertFunction<TSchemaName extends SchemaName> = (
   message: Extract<ProtoTypesWithSchemaInfo, { schemaName: TSchemaName }>,
   versionObj: VersionObj
-) => FilterBySchemaName<JsonSchemaTypes, TSchemaName>
+) => FilterBySchemaName<MapeoDoc, TSchemaName>
 
 export const convertProject: ConvertFunction<'project'> = (
   message,
@@ -52,7 +52,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
   }
 }
 
-type FieldOptions = FilterBySchemaName<JsonSchemaTypes, 'field'>['options']
+type FieldOptions = FilterBySchemaName<MapeoDoc, 'field'>['options']
 
 export const convertField: ConvertFunction<'field'> = (message, versionObj) => {
   const { common, schemaVersion, ...rest } = message
@@ -87,7 +87,7 @@ export const convertField: ConvertFunction<'field'> = (message, versionObj) => {
 }
 
 type JsonSchemaPresetGeomItem = FilterBySchemaName<
-  JsonSchemaTypes,
+  MapeoDoc,
   'preset'
 >['geometry'][number]
 
@@ -172,7 +172,7 @@ function convertTagPrimitive({
 function convertCommon(
   common: ProtoTypesWithSchemaInfo['common'],
   versionObj: VersionObj
-): JsonSchemaCommon {
+): MapeoCommon {
   if (!common || !common.docId || !common.createdAt || !common.updatedAt) {
     throw new Error('Missing required common properties')
   }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -1,9 +1,9 @@
 import { CurrentProtoTypes } from '../proto/types.js'
 import {
-  JsonSchemaTypes,
+  MapeoDoc,
   ProtoTypesWithSchemaInfo,
   SchemaName,
-  JsonSchemaCommon,
+  MapeoCommon,
   TagValuePrimitive,
   JsonTagValue,
   VersionObj,
@@ -15,10 +15,7 @@ import { Observation_5_Metadata } from '../proto/observation/v5.js'
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
 type ConvertFunction<TSchemaName extends SchemaName> = (
-  mapeoDoc: Extract<
-    OmitUnion<JsonSchemaTypes, 'version'>,
-    { schemaName: TSchemaName }
-  >
+  mapeoDoc: Extract<OmitUnion<MapeoDoc, 'version'>, { schemaName: TSchemaName }>
 ) => CurrentProtoTypes[TSchemaName]
 
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
@@ -88,7 +85,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
 }
 
 function convertCommon(
-  common: Omit<JsonSchemaCommon, 'version'>
+  common: Omit<MapeoCommon, 'version'>
 ): ProtoTypesWithSchemaInfo['common'] {
   return {
     docId: Buffer.from(common.docId, 'hex'),

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -91,7 +91,7 @@ function convertCommon(
   common: Omit<JsonSchemaCommon, 'version'>
 ): ProtoTypesWithSchemaInfo['common'] {
   return {
-    id: Buffer.from(common.id, 'hex'),
+    docId: Buffer.from(common.docId, 'hex'),
     createdAt: common.createdAt,
     updatedAt: common.updatedAt,
     links: common.links.map((link) => versionStringToObj(link)),

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ type ProtoTypeCommonKeys = keyof Exclude<
 /** Just the common (shared) props from JSON schema types */
 export type JsonSchemaCommon = Pick<
   JsonSchemaTypes,
-  ProtoTypeCommonKeys | 'version'
+  ProtoTypeCommonKeys | 'versionId'
 >
 
 /** Filter a union of objects to only include those that have a prop `schemaName` that matches U */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 // Shared types
 import { type ProtoTypesWithSchemaInfo as AllProtoTypesWithSchemaInfo } from './proto/types.js'
-import { type JsonSchemaTypes as AllJsonSchemaTypes } from './schema/index.js'
+import { type MapeoDoc as AllMapeoDocs, MapeoCommon } from './schema/index.js'
 import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
@@ -20,17 +20,7 @@ export type JsonTagValue =
   | TagValuePrimitive
   | Array<Exclude<TagValuePrimitive, undefined>>
 
-/** Union of keys from the common prop on Proto types */
-type ProtoTypeCommonKeys = keyof Exclude<
-  ProtoTypesWithSchemaInfo['common'],
-  undefined
->
-
-/** Just the common (shared) props from JSON schema types */
-export type JsonSchemaCommon = Pick<
-  JsonSchemaTypes,
-  ProtoTypeCommonKeys | 'versionId'
->
+export { MapeoCommon }
 
 /** Filter a union of objects to only include those that have a prop `schemaName` that matches U */
 export type FilterBySchemaName<
@@ -48,10 +38,7 @@ export type ProtoTypesWithSchemaInfo = FilterBySchemaName<
 >
 
 /** Only jsonschema types we currently support (whilst in dev) */
-export type JsonSchemaTypes = FilterBySchemaName<
-  AllJsonSchemaTypes,
-  SupportedSchemaNames
->
+export type MapeoDoc = FilterBySchemaName<AllMapeoDocs, SupportedSchemaNames>
 
 /** Union of all valid data type ids */
 export type DataTypeId = Values<typeof dataTypeIds>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 // Shared types
 import { type ProtoTypesWithSchemaInfo as AllProtoTypesWithSchemaInfo } from './proto/types.js'
-import { type MapeoDoc as AllMapeoDocs, MapeoCommon } from './schema/index.js'
+import {
+  type MapeoDoc as AllMapeoDocs,
+  type MapeoValue as AllMapeoValues,
+  type MapeoCommon,
+} from './schema/index.js'
 import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
@@ -39,6 +43,10 @@ export type ProtoTypesWithSchemaInfo = FilterBySchemaName<
 
 /** Only jsonschema types we currently support (whilst in dev) */
 export type MapeoDoc = FilterBySchemaName<AllMapeoDocs, SupportedSchemaNames>
+export type MapeoValue = FilterBySchemaName<
+  AllMapeoValues,
+  SupportedSchemaNames
+>
 
 /** Union of all valid data type ids */
 export type DataTypeId = Values<typeof dataTypeIds>

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,17 @@
+import { MapeoValue, FilterBySchemaName, SchemaName } from './types.js'
 import * as validations from './validations.js'
 
-export function validate(schemaName: keyof typeof validations, obj: unknown) {
+export function validate<
+  TSchemaName extends Extract<keyof typeof validations, SchemaName>
+>(
+  schemaName: TSchemaName,
+  obj: unknown
+): obj is FilterBySchemaName<MapeoValue, TSchemaName> {
   return validations[schemaName](obj)
+}
+
+let obj = JSON.parse('')
+
+if (validate('observation', obj)) {
+  obj.attachments
 }


### PR DESCRIPTION
Following discussion with @achou11:

- Rename `id` -> `docId`
- Rename `version` -> `versionId`
- Export types for "values", e.g. without common props. These are the types for update/create actions.
- Name "value" types as `${schemaName}Value`
- Rename union of all Mapeo types as `MapeoDoc`