### PR TITLE
feat: opaque types [6/6]

### DIFF
--- a/scripts/lib/generate-jsonschema-ts.js
+++ b/scripts/lib/generate-jsonschema-ts.js
@@ -32,8 +32,9 @@ export async function generateJSONSchemaTS(config, jsonSchemas) {
   }
 
   indexLines.push(
+    "import { type Opaque } from '../types.js'",
     '',
-    'export type MapeoCommon = Simplify<_Common>',
+    'export type MapeoCommon = Simplify<_Common & { docId: Opaque<string>, versionId: Opaque<string> }>',
     '',
     'type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};',
     ''
@@ -44,9 +45,15 @@ export async function generateJSONSchemaTS(config, jsonSchemas) {
     const typeName = capitalize(schemaName)
     const interfaceName = '_' + typeName
     const valueName = getValueName(schemaName)
+    indexLines.push(
+      `export type ${typeName}DocId = Opaque<string, '${schemaName}DocId'>`
+    )
+    indexLines.push(
+      `export type ${typeName}VersionId = Opaque<string, '${schemaName}VersionId'>`
+    )
     if (schema.description) indexLines.push(`/** ${schema.description} */`)
     indexLines.push(
-      `export type ${typeName} = Simplify<${interfaceName} & _Common>`
+      `export type ${typeName} = Simplify<${interfaceName} & _Common & { docId: ${typeName}DocId, versionId: ${typeName}VersionId }>`
     )
     if (schema.description) indexLines.push(`/** ${schema.description} */`)
     // Unwrap generated TS, from an interface to a type alias, for improved type

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,3 +63,18 @@ export type OmitUnion<T, K extends keyof any> = T extends any
   : never
 /** Return a union of object values */
 type Values<T> = T[keyof T]
+
+declare const tag: unique symbol
+
+type Tagged<Token> = {
+  readonly [tag]: Token
+}
+
+/**
+Create an opaque type, which hides its internal details from the public, and can only be created by being used explicitly.
+
+The generic type parameter can be anything. It doesn't have to be an object.
+
+https://github.com/sindresorhus/type-fest/blob/main/source/opaque.d.ts
+*/
+export type Opaque<Type, Token = unknown> = Type & Tagged<Token>


### PR DESCRIPTION
This ensures that the client does not try to generate these themselves,
and avoids errors from assigning another string to these values. They
should always come from database reads, and their use should be scoped
to documents of the same schema type. The opaque types ensure that.