### PR TITLE
fix: observation.metadata should be required.

### DIFF
--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -186,6 +186,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["schemaName", "tags", "refs", "attachments"],
+  "required": ["schemaName", "tags", "refs", "attachments", "metadata"],
   "additionalProperties": false
 }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -49,6 +49,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
       return { driveId: driveId.toString('hex'), name, type }
     }),
     tags: convertTags(message.tags),
+    metadata: message.metadata || {},
   }
 }
 


### PR DESCRIPTION
All top-level properties that are objects or arrays should be required (default to `{}` and `[]`)