### PR TITLE
feat: add missing fields to authStore schemas/protos

### DIFF
--- a/proto/coreOwnership/v1.proto
+++ b/proto/coreOwnership/v1.proto
@@ -20,4 +20,6 @@ message CoreOwnership_1 {
   string signature = 9;
   int32 authorIndex = 10;
   int32 deviceIndex = 11;
+  bytes authorId = 12;
+  string capabilityType = 13;
 }

--- a/proto/device/v1.proto
+++ b/proto/device/v1.proto
@@ -19,4 +19,5 @@ message Device_1 {
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;
+  string capabilityType = 11;
 }

--- a/proto/role/v1.proto
+++ b/proto/role/v1.proto
@@ -19,4 +19,6 @@ message Role_1 {
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;
+  bytes authorId = 11;
+  string capabilityType = 12;
 }

--- a/schema/coreOwnership/v1.json
+++ b/schema/coreOwnership/v1.json
@@ -16,7 +16,8 @@
     "storeType": { "type": "string" },
     "signature": { "type": "string" },
     "authorIndex": { "type": "integer" },
-    "deviceIndex": { "type": "integer" }
+    "deviceIndex": { "type": "integer" },
+    "authorId": {"type": "string"}
   },
   "required": ["schemaName"]
 }

--- a/schema/device/v1.json
+++ b/schema/device/v1.json
@@ -25,6 +25,9 @@
     },
     "deviceIndex": {
       "type": "integer"
+    },
+    "capabilityType": {
+      "type": "string"
     }
   },
   "required": ["schemaName"],

--- a/schema/role/v1.json
+++ b/schema/role/v1.json
@@ -26,6 +26,12 @@
     },
     "deviceIndex": {
       "type": "integer"
+    },
+    "authorId": {
+      "type": "string"
+    },
+    "capabilityType": {
+      "type": "string"
     }
   },
   "required": ["schemaName"],


### PR DESCRIPTION
This PR adds missing fields to authStore Schemas and protobufs. 
Things that can be revised:
* some fields name *Id that are typed as `string` on the protobuf could be of type `bytes`.
* `capabilityType` is a `string` but can be an `enum`. Looking at [this code](https://github.com/digidem/mapeo-core-next/blob/main/lib/authstore/authtypes.js) I don't know this should be the name of the role (`projectCreator | coordinator | member | non-member`) or the capabilities (`read | write | manage:devices`).

This should close PR #44 