### PR TITLE
fix: change schemaName from enum to const

### DIFF
--- a/schema/coreOwnership/v1.json
+++ b/schema/coreOwnership/v1.json
@@ -6,7 +6,7 @@
   "properties": {
     "schemaName": {
       "type": "string",
-      "enum": ["coreOwnership"]
+      "const": "coreOwnership"
     },
     "action": {
       "type": "string"

--- a/schema/device/v1.json
+++ b/schema/device/v1.json
@@ -6,7 +6,7 @@
   "properties": {
     "schemaName": {
       "type": "string",
-      "enum": ["device"]
+      "const": "device"
     },
     "action": {
       "type": "string"

--- a/schema/field/v2.json
+++ b/schema/field/v2.json
@@ -8,7 +8,7 @@
     "schemaName": {
       "description": "Must be `field`",
       "type": "string",
-      "enum": ["field"]
+      "const": "field"
     },
     "tagKey": {
       "description": "They key in a tags object that this field applies to",

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -51,7 +51,7 @@
     "schemaName": {
       "description": "Must be `observation`",
       "type": "string",
-      "enum": ["observation"]
+      "const": "observation"
     },
     "lat": {
       "description": "latitude of the observation",

--- a/schema/preset/v2.json
+++ b/schema/preset/v2.json
@@ -49,7 +49,7 @@
     "schemaName": {
       "description": "Must be `preset`",
       "type": "string",
-      "enum": ["preset"]
+      "const": "preset"
     },
     "name": {
       "description": "Name for the feature in default language.",

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -7,7 +7,7 @@
     "schemaName": {
       "description": "Must be `project`",
       "type": "string",
-      "enum": ["project"]
+      "const": "project"
     },
     "name": {
       "description": "name of the project",

--- a/schema/project/v2.json
+++ b/schema/project/v2.json
@@ -7,7 +7,7 @@
     "schemaName": {
       "description": "Must be `project`",
       "type": "string",
-      "enum": ["project"]
+      "const": "project"
     },
     "name": {
       "description": "name of the project",

--- a/schema/role/v1.json
+++ b/schema/role/v1.json
@@ -6,7 +6,7 @@
   "properties": {
     "schemaName": {
       "type": "string",
-      "enum": ["role"]
+      "const": "role"
     },
     "role": {
       "type": "string"

--- a/scripts/lib/read-json-schema.js
+++ b/scripts/lib/read-json-schema.js
@@ -31,8 +31,10 @@ export function readJSONSchema({ currentSchemaVersions }) {
     const jsonSchema = readJSON(filepath)
     const { dir, name } = path.parse(filepath)
     const folderName = path.basename(dir)
-    // @ts-ignore - enum not defined on JSONSchema v7
-    const schemaName = jsonSchema.properties?.schemaName?.enum[0]
+    const schemaName =
+      typeof jsonSchema.properties?.schemaName !== 'boolean'
+        ? jsonSchema.properties?.schemaName.const
+        : undefined
     if (folderName !== schemaName) {
       throw new Error(`Unexpected schemaName '${schemaName}' in ${filepath}`)
     }


### PR DESCRIPTION
We had been using `enum` to define the `schemaName` property, however this was proving challenging to work with in the Mapeo Core code - it's easier if we use the `const` keyword, which is more appropriate for this (although they essentially do the same thing).