### PR TITLE
Conversion functions for authStore types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -956,7 +956,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -1659,7 +1659,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "function-bind": {
@@ -2015,7 +2015,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -2283,7 +2283,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "isomorphic-fetch": {
       "version": "3.0.0",
@@ -2978,7 +2978,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -3069,7 +3069,7 @@
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
@@ -3261,7 +3261,7 @@
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
       "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
@@ -3891,7 +3891,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-indent": {
@@ -4314,7 +4314,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "xache": {

--- a/proto/coreOwnership/v1.proto
+++ b/proto/coreOwnership/v1.proto
@@ -20,4 +20,6 @@ message CoreOwnership_1 {
   string signature = 9;
   int32 authorIndex = 10;
   int32 deviceIndex = 11;
+  bytes authorId = 12;
+  string capabilityType = 13;
 }

--- a/proto/coreOwnership/v1.proto
+++ b/proto/coreOwnership/v1.proto
@@ -14,8 +14,8 @@ message CoreOwnership_1 {
   Common_1 common = 1;
 
   string action = 5;
-  string coreId = 6;
-  string projectId = 7;
+  bytes coreId = 6;
+  bytes projectId = 7;
   string storeType = 8;
   string signature = 9;
   int32 authorIndex = 10;

--- a/proto/device/v1.proto
+++ b/proto/device/v1.proto
@@ -14,8 +14,8 @@ message Device_1 {
   Common_1 common = 1;
 
   string action = 5;
-  string authorId = 6;
-  string projectId = 7;
+  bytes authorId = 6;
+  bytes projectId = 7;
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;

--- a/proto/device/v1.proto
+++ b/proto/device/v1.proto
@@ -19,4 +19,5 @@ message Device_1 {
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;
+  string capabilityType = 11;
 }

--- a/proto/role/v1.proto
+++ b/proto/role/v1.proto
@@ -19,7 +19,7 @@ message Role_1 {
     role_set = 0;
     role_unset = 1;
   };
-  Action action = 7 [(required) = true];
+  Action action = 7;
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;

--- a/proto/role/v1.proto
+++ b/proto/role/v1.proto
@@ -15,7 +15,11 @@ message Role_1 {
 
   string role = 5;
   string projectId = 6;
-  string action = 7;
+  enum Action {
+    role_set = 0;
+    role_unset = 1;
+  };
+  Action action = 7 [(required) = true];
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;

--- a/proto/role/v1.proto
+++ b/proto/role/v1.proto
@@ -19,4 +19,6 @@ message Role_1 {
   string signature = 8;
   int32 authorIndex = 9;
   int32 deviceIndex = 10;
+  bytes authorId = 11;
+  string capabilityType = 12;
 }

--- a/proto/role/v1.proto
+++ b/proto/role/v1.proto
@@ -14,7 +14,7 @@ message Role_1 {
   Common_1 common = 1;
 
   string role = 5;
-  string projectId = 6;
+  bytes projectId = 6;
   enum Action {
     role_set = 0;
     role_unset = 1;

--- a/schema/coreOwnership/v1.json
+++ b/schema/coreOwnership/v1.json
@@ -17,7 +17,8 @@
     "signature": { "type": "string" },
     "authorIndex": { "type": "integer" },
     "deviceIndex": { "type": "integer" },
-    "authorId": {"type": "string"}
+    "authorId": {"type": "string"},
+    "capabilityType": {"type": "string"}
   },
-  "required": ["schemaName"]
+  "required": ["schemaName", "action", "coreId", "projectId", "storeType", "signature", "authorIndex", "deviceIndex", "authorId", "capabilityType"]
 }

--- a/schema/coreOwnership/v1.json
+++ b/schema/coreOwnership/v1.json
@@ -16,7 +16,8 @@
     "storeType": { "type": "string" },
     "signature": { "type": "string" },
     "authorIndex": { "type": "integer" },
-    "deviceIndex": { "type": "integer" }
+    "deviceIndex": { "type": "integer" },
+    "authorId": {"type": "string"}
   },
   "required": ["schemaName"]
 }

--- a/schema/device/v1.json
+++ b/schema/device/v1.json
@@ -25,6 +25,9 @@
     },
     "deviceIndex": {
       "type": "integer"
+    },
+    "capabilityType": {
+      "type": "string"
     }
   },
   "required": ["schemaName"],

--- a/schema/device/v1.json
+++ b/schema/device/v1.json
@@ -30,6 +30,6 @@
       "type": "string"
     }
   },
-  "required": ["schemaName"],
+  "required": ["schemaName", "action", "authorId", "projectId", "signature", "authorIndex", "deviceIndex", "capabilityType"],
   "additionalProperties": false
 }

--- a/schema/role/v1.json
+++ b/schema/role/v1.json
@@ -26,6 +26,12 @@
     },
     "deviceIndex": {
       "type": "integer"
+    },
+    "authorId": {
+      "type": "string"
+    },
+    "capabilityType": {
+      "type": "string"
     }
   },
   "required": ["schemaName"],

--- a/schema/role/v1.json
+++ b/schema/role/v1.json
@@ -16,7 +16,7 @@
     },
     "action": {
       "type": "string",
-      "enum": ["role_set", "role_unset"]
+      "enum": ["role_set", "role_unset", "UNRECOGNIZED"]
     },
     "signature": {
       "type": "string"

--- a/schema/role/v1.json
+++ b/schema/role/v1.json
@@ -16,7 +16,7 @@
     },
     "action": {
       "type": "string",
-      "enum": ["role:set"]
+      "enum": ["role_set", "role_unset"]
     },
     "signature": {
       "type": "string"
@@ -34,6 +34,6 @@
       "type": "string"
     }
   },
-  "required": ["schemaName"],
+  "required": ["schemaName", "role", "projectId", "action", "signature", "authorIndex", "deviceIndex", "authorId", "capabilityType"],
   "additionalProperties": false
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -16,7 +16,8 @@ import {
   convertObservation,
   convertPreset,
   convertRole,
-  convertDevice
+  convertDevice,
+  convertCoreOwnership
 } from './lib/decode-conversions.js'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
@@ -63,6 +64,8 @@ export function decode(buf: Buffer, versionObj: VersionObj): MapeoDoc {
       return convertRole(message,versionObj)
     case 'device':
       return convertDevice(message,versionObj)
+    case 'coreOwnership':
+      return convertCoreOwnership(message,versionObj)
     default:
       const _exhaustiveCheck: never = message
       return message

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -15,7 +15,8 @@ import {
   convertField,
   convertObservation,
   convertPreset,
-  convertRole
+  convertRole,
+  convertDevice
 } from './lib/decode-conversions.js'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
@@ -60,6 +61,8 @@ export function decode(buf: Buffer, versionObj: VersionObj): MapeoDoc {
       return convertPreset(message, versionObj)
     case 'role':
       return convertRole(message,versionObj)
+    case 'device':
+      return convertDevice(message,versionObj)
     default:
       const _exhaustiveCheck: never = message
       return message

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -15,6 +15,7 @@ import {
   convertField,
   convertObservation,
   convertPreset,
+  convertRole
 } from './lib/decode-conversions.js'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
@@ -57,6 +58,8 @@ export function decode(buf: Buffer, versionObj: VersionObj): MapeoDoc {
       return convertField(message, versionObj)
     case 'preset':
       return convertPreset(message, versionObj)
+    case 'role':
+      return convertRole(message,versionObj)
     default:
       const _exhaustiveCheck: never = message
       return message

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -9,7 +9,8 @@ import {
   convertObservation,
   convertPreset,
   convertProject,
-  convertRole
+  convertRole,
+  convertDevice,
 } from './lib/encode-converstions.js'
 
 /**
@@ -49,6 +50,11 @@ export function encode(mapeoDoc: OmitUnion<MapeoDoc, 'version'>): Buffer {
     }
     case 'role': {
       const message = convertRole(mapeoDoc)
+      protobuf = Encode[mapeoDoc.schemaName](message).finish()
+      break
+    }
+    case 'device': {
+      const message = convertDevice(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -11,6 +11,7 @@ import {
   convertProject,
   convertRole,
   convertDevice,
+  convertCoreOwnership,
 } from './lib/encode-converstions.js'
 
 /**
@@ -55,6 +56,11 @@ export function encode(mapeoDoc: OmitUnion<MapeoDoc, 'version'>): Buffer {
     }
     case 'device': {
       const message = convertDevice(mapeoDoc)
+      protobuf = Encode[mapeoDoc.schemaName](message).finish()
+      break
+    }
+    case 'coreOwnership': {
+      const message = convertCoreOwnership(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -9,6 +9,7 @@ import {
   convertObservation,
   convertPreset,
   convertProject,
+  convertRole
 } from './lib/encode-converstions.js'
 
 /**
@@ -43,6 +44,11 @@ export function encode(mapeoDoc: OmitUnion<MapeoDoc, 'version'>): Buffer {
     }
     case 'preset': {
       const message = convertPreset(mapeoDoc)
+      protobuf = Encode[mapeoDoc.schemaName](message).finish()
+      break
+    }
+    case 'role': {
+      const message = convertRole(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -125,6 +125,7 @@ versionObj
       ...rest,
     role: rest.role,
     action: message.action == 'UNRECOGNIZED' ? 'role_set' : message.action,
+    projectId: message.projectId.toString('hex'),
     authorId: message.authorId.toString('hex')
     }
 }
@@ -137,7 +138,9 @@ export const convertDevice: ConvertFunction<'device'> = (
   const jsonSchemaCommon = convertCommon(common, versionObj)
   return {
     ...jsonSchemaCommon,
-    ...rest
+    ...rest,
+    authorId: message.authorId.toString('hex'),
+    projectId: message.projectId.toString('hex')
   }
 }
 
@@ -150,6 +153,8 @@ export const convertCoreOwnership: ConvertFunction<'coreOwnership'> = (
   return {
     ...jsonSchemaCommon,
     ...rest,
+    coreId: message.coreId.toString('hex'),
+    projectId: message.projectId.toString('hex'),
     authorId: message.authorId.toString('hex')
   }
 

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -114,6 +114,21 @@ export const convertPreset: ConvertFunction<'preset'> = (
   }
 }
 
+export const convertRole: ConvertFunction<'role'> = (
+message,
+versionObj
+) => {
+    const { common, schemaVersion, ...rest } = message
+    const jsonSchemaCommon = convertCommon(common, versionObj)
+    return {
+      ...jsonSchemaCommon,
+      ...rest,
+    role: rest.role,
+    action: message.action == 'UNRECOGNIZED' ? 'role_set' : message.action,
+    authorId: message.authorId.toString('hex')
+    }
+}
+
 function convertTags(tags: { [key: string]: TagValue_1 } | undefined): {
   [key: string]: Exclude<JsonTagValue, undefined>
 } {

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -124,7 +124,6 @@ versionObj
       ...jsonSchemaCommon,
       ...rest,
     role: rest.role,
-    action: message.action == 'UNRECOGNIZED' ? 'role_set' : message.action,
     projectId: message.projectId.toString('hex'),
     authorId: message.authorId.toString('hex')
     }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -141,6 +141,20 @@ export const convertDevice: ConvertFunction<'device'> = (
   }
 }
 
+export const convertCoreOwnership: ConvertFunction<'coreOwnership'> = (
+  message,
+  versionObj
+) => {
+  const { common, schemaVersion, ...rest } = message
+  const jsonSchemaCommon = convertCommon(common, versionObj)
+  return {
+    ...jsonSchemaCommon,
+    ...rest,
+    authorId: message.authorId.toString('hex')
+  }
+
+}
+
 function convertTags(tags: { [key: string]: TagValue_1 } | undefined): {
   [key: string]: Exclude<JsonTagValue, undefined>
 } {

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -129,6 +129,18 @@ versionObj
     }
 }
 
+export const convertDevice: ConvertFunction<'device'> = (
+  message,
+  versionObj
+) => {
+  const { common, schemaVersion, ...rest } = message
+  const jsonSchemaCommon = convertCommon(common, versionObj)
+  return {
+    ...jsonSchemaCommon,
+    ...rest
+  }
+}
+
 function convertTags(tags: { [key: string]: TagValue_1 } | undefined): {
   [key: string]: Exclude<JsonTagValue, undefined>
 } {

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -95,6 +95,15 @@ export const convertRole: ConvertFunction<'role'> = (
   }
 }
 
+export const convertDevice: ConvertFunction<'device'> = (
+  mapeoDoc
+) => {
+  return {
+    common: convertCommon(mapeoDoc),
+    ...mapeoDoc
+  }
+}
+
 function convertCommon(
   common: Omit<MapeoCommon, 'version'>
 ): ProtoTypesWithSchemaInfo['common'] {

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -90,6 +90,7 @@ export const convertRole: ConvertFunction<'role'> = (
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
+    projectId: Buffer.from(mapeoDoc.projectId,'hex'),
     authorId: Buffer.from(mapeoDoc.authorId,'hex')
 
   }
@@ -100,7 +101,9 @@ export const convertDevice: ConvertFunction<'device'> = (
 ) => {
   return {
     common: convertCommon(mapeoDoc),
-    ...mapeoDoc
+    ...mapeoDoc,
+    authorId: Buffer.from(mapeoDoc.authorId, 'hex'),
+    projectId: Buffer.from(mapeoDoc.projectId, 'hex')
   }
 }
 
@@ -110,6 +113,8 @@ export const convertCoreOwnership: ConvertFunction<'coreOwnership'> = (
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
+    coreId: Buffer.from(mapeoDoc.coreId, 'hex'),
+    projectId: Buffer.from(mapeoDoc.projectId, 'hex'),
     authorId: Buffer.from(mapeoDoc.authorId,'hex')
   }
 }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -104,6 +104,16 @@ export const convertDevice: ConvertFunction<'device'> = (
   }
 }
 
+export const convertCoreOwnership: ConvertFunction<'coreOwnership'> = (
+  mapeoDoc
+) => {
+  return {
+    common: convertCommon(mapeoDoc),
+    ...mapeoDoc,
+    authorId: Buffer.from(mapeoDoc.authorId,'hex')
+  }
+}
+
 function convertCommon(
   common: Omit<MapeoCommon, 'version'>
 ): ProtoTypesWithSchemaInfo['common'] {

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -84,6 +84,17 @@ export const convertObservation: ConvertFunction<'observation'> = (
   }
 }
 
+export const convertRole: ConvertFunction<'role'> = (
+  mapeoDoc
+) => {
+  return {
+    common: convertCommon(mapeoDoc),
+    ...mapeoDoc,
+    authorId: Buffer.from(mapeoDoc.authorId,'hex')
+
+  }
+}
+
 function convertCommon(
   common: Omit<MapeoCommon, 'version'>
 ): ProtoTypesWithSchemaInfo['common'] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
 import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
-type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset' | 'role'
+type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset' | 'role' | 'device'
 
 export type SchemaName = Extract<keyof typeof dataTypeIds, SupportedSchemaNames>
 export type SchemaNameAll = keyof typeof dataTypeIds

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
 import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
-type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset'
+type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset' | 'role'
 
 export type SchemaName = Extract<keyof typeof dataTypeIds, SupportedSchemaNames>
 export type SchemaNameAll = keyof typeof dataTypeIds

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
 import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
-type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset' | 'role' | 'device'
+type SupportedSchemaNames = 'project' | 'observation' | 'field' | 'preset' | 'role' | 'device' | 'coreOwnership'
 
 export type SchemaName = Extract<keyof typeof dataTypeIds, SupportedSchemaNames>
 export type SchemaNameAll = keyof typeof dataTypeIds


### PR DESCRIPTION
Things to consider:
* what fields are required? 
  * Role: every field
  * Device: every field
  * coreOwnership: every field
* Device: actions are strings. When we know possible actions, it should be an enum.
* action name delimiters:
  protobuf doesn't allow colons (':') on identifiers, so to avoid type problems I basically replaced that delimiter with underscore ('_'). So in schemas `role:set` becomes `role_set`. Another separator could be chosen, or a convertion function (convertAction) could be written; I've tried but failed with that