### PR TITLE
feat: add defaultPresets to Project doc

### DIFF
--- a/proto/project/v1.proto
+++ b/proto/project/v1.proto
@@ -12,19 +12,12 @@ message Project_1 {
 
   Common_1 common = 1;
 
+  message DefaultPresets {
+    repeated string point = 1;
+    repeated string area = 2;
+  };
+
+  DefaultPresets defaultPresets = 2;
+
   string name = 5;
-  /*
-  // You can't use an enum as a key in a map in protobufs :(
-  enum DefaultPresetsKey {
-    point = 0;
-    vertex = 1;
-    line = 2;
-    area = 3;
-    relation = 4;
-  };
-  message DefaultPresetsValue {
-    repeated string defaultPresetsValue = 1;
-  };
-  map<DefaultPresetsKey,DefaultPresetsValue> defaultPresetsValue= 6;
-  */
 }

--- a/proto/project/v1.proto
+++ b/proto/project/v1.proto
@@ -13,8 +13,11 @@ message Project_1 {
   Common_1 common = 1;
 
   message DefaultPresets {
-    repeated string point = 1;
-    repeated string area = 2;
+    repeated bytes point = 1;
+    repeated bytes area = 2;
+    repeated bytes vertex = 3;
+    repeated bytes line = 4;
+    repeated bytes relation = 5;
   };
 
   DefaultPresets defaultPresets = 2;

--- a/proto/project/v2.proto
+++ b/proto/project/v2.proto
@@ -14,5 +14,12 @@ message Project_2 {
 
   Common_1 common = 1;
 
+  message DefaultPresets {
+    repeated string point = 1;
+    repeated string area = 2;
+  };
+
+  DefaultPresets defaultPresets = 2;
+
   string name = 5;
 }

--- a/proto/project/v2.proto
+++ b/proto/project/v2.proto
@@ -15,8 +15,11 @@ message Project_2 {
   Common_1 common = 1;
 
   message DefaultPresets {
-    repeated string point = 1;
-    repeated string area = 2;
+    repeated bytes point = 1;
+    repeated bytes area = 2;
+    repeated bytes vertex = 3;
+    repeated bytes line = 4;
+    repeated bytes relation = 5;
   };
 
   DefaultPresets defaultPresets = 2;

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -17,7 +17,10 @@
       "type": "object",
       "properties": {
         "point": { "type": "array", "items":{"type":"string"}},
-        "area": { "type": "array", "items":{"type":"string"}}
+        "area": { "type": "array", "items":{"type":"string"}},
+        "vertex": { "type": "array", "items":{"type":"string"}},
+        "line": { "type": "array", "items":{"type":"string"}},
+        "relation": { "type": "array", "items":{"type":"string"}}
       }
     }
   },

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -12,8 +12,15 @@
     "name": {
       "description": "name of the project",
       "type": "string"
+    },
+    "defaultPresets":{
+      "type": "object",
+      "properties": {
+        "point": { "type": "array", "items":{"type":"string"}},
+        "area": { "type": "array", "items":{"type":"string"}}
+      }
     }
   },
-  "required": ["schemaName", "name"],
+  "required": ["schemaName", "name", "defaultPresets"],
   "additionalProperties": false
 }

--- a/schema/project/v2.json
+++ b/schema/project/v2.json
@@ -17,7 +17,10 @@
       "type": "object",
       "properties": {
         "point": { "type": "array", "items":{"type":"string"}},
-        "area": { "type": "array", "items":{"type":"string"}}
+        "area": { "type": "array", "items":{"type":"string"}},
+        "vertex": { "type": "array", "items":{"type":"string"}},
+        "line": { "type": "array", "items":{"type":"string"}},
+        "relation": { "type": "array", "items":{"type":"string"}}
       }
     }
   },

--- a/schema/project/v2.json
+++ b/schema/project/v2.json
@@ -12,8 +12,15 @@
     "name": {
       "description": "name of the project",
       "type": "string"
+    },
+    "defaultPresets": {
+      "type": "object",
+      "properties": {
+        "point": { "type": "array", "items":{"type":"string"}},
+        "area": { "type": "array", "items":{"type":"string"}}
+      }
     }
   },
-  "required": ["schemaName", "name"],
+  "required": ["schemaName", "name", "defaultPresets"],
   "additionalProperties": false
 }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -31,7 +31,13 @@ export const convertProject: ConvertFunction<'project'> = (
   return {
     ...jsonSchemaCommon,
     ...rest,
-    defaultPresets: message.defaultPresets || {}
+    defaultPresets: {
+      point: message.defaultPresets?.point.map(p => p.toString('hex')),
+      area: message.defaultPresets?.area.map(a => a.toString('hex')),
+      vertex: message.defaultPresets?.vertex.map(v => v.toString('hex')),
+      line: message.defaultPresets?.line.map(l => l.toString('hex')),
+      relation: message.defaultPresets?.relation.map(r => r.toString('hex')),
+    } || {}
   }
 }
 

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -37,7 +37,7 @@ export const convertProject: ConvertFunction<'project'> = (
       vertex: message.defaultPresets?.vertex.map(v => v.toString('hex')),
       line: message.defaultPresets?.line.map(l => l.toString('hex')),
       relation: message.defaultPresets?.relation.map(r => r.toString('hex')),
-    } || {}
+    }
   }
 }
 

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -31,6 +31,7 @@ export const convertProject: ConvertFunction<'project'> = (
   return {
     ...jsonSchemaCommon,
     ...rest,
+    defaultPresets: message.defaultPresets || {}
   }
 }
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -22,6 +22,10 @@ export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
+    defaultPresets: {
+      point: mapeoDoc.defaultPresets?.point || [],
+      area: mapeoDoc.defaultPresets?.area || []
+    } || {}
   }
 }
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -23,9 +23,12 @@ export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
     defaultPresets: {
-      point: mapeoDoc.defaultPresets?.point || [],
-      area: mapeoDoc.defaultPresets?.area || []
-    } || {}
+      point: (mapeoDoc.defaultPresets.point || []).map(p => Buffer.from(p,'hex')),
+      area: (mapeoDoc.defaultPresets.area || []).map(a => Buffer.from(a,'hex')),
+      vertex: (mapeoDoc.defaultPresets.area || []).map(v => Buffer.from(v,'hex')),
+      line: (mapeoDoc.defaultPresets.area || []).map(l => Buffer.from(l, 'hex')),
+      relation: (mapeoDoc.defaultPresets.area || []).map(r => Buffer.from(r, 'hex'))
+    }
   }
 }
 


### PR DESCRIPTION
Added `defaultPresets` as an object with `point (string[])` and `area (string[])`.

Since project has two versions for testing foward compatibility I added the field to both of them, but it maybe a good choice to only add it to the newest (v2) so to test foward compatibility on conversion functions (maybe outside of the scope of this tickets). I don't know if having a check for `schemaVersion` on the `decode-conversions.ts/convertProject` function would suffice (it seems like it...)
