### PR TITLE
feat: export fns for versionId, seq->index, coreId->coreKey

### DIFF
--- a/examples/schema_test.js
+++ b/examples/schema_test.js
@@ -20,7 +20,7 @@ async function test(key) {
     const index = 0
     const data = await core.get(index)
     console.log(`trying ${k}`)
-    const decodedData = decode(data, { coreId: core.key, seq: index })
+    const decodedData = decode(data, { coreKey: core.key, index })
     console.log('data', decodedData)
     console.log(`VALID? `, validate(decodedData), '\n')
     if (Buffer.compare(data, record) !== 0) {

--- a/proto/common/v1.proto
+++ b/proto/common/v1.proto
@@ -8,8 +8,8 @@ message Common_1 {
   // 32-byte random generated number
   optional bytes docId = 1 [(required) = true];
   message Link {
-    bytes coreId = 1;
-    int32 seq = 2;
+    bytes coreKey = 1;
+    int32 index = 2;
   }
   repeated Link links = 2;
   google.protobuf.Timestamp createdAt = 3 [(required) = true];
@@ -19,5 +19,5 @@ message Common_1 {
  * id is a byte buffer here and a string in jsonSchema
  * schemaVersion is encoded on the blockPrefix
  * dataTypeId is encoded on the blockPrefix
- * version is the core seq number so wen can avoid it here
+ * version is the core key and index number so we can avoid it here
  */

--- a/schema/common/v1.json
+++ b/schema/common/v1.json
@@ -10,7 +10,7 @@
       "type": "string"
     },
     "versionId": {
-      "description": "id (hex-encoded 32-byte buffer) and core sequence number, separated by '/'",
+      "description": "core id (hex-encoded 32-byte buffer) and core index number, separated by '/'",
       "type": "string"
     },
     "schemaName": {
@@ -28,7 +28,7 @@
       "format": "date-time"
     },
     "links": {
-      "description": "Version ids of the previous document versions this one is replacing. Each link is id (hex-encoded 32 byte buffer) and sequence number, separated by '/'",
+      "description": "Version ids of the previous document versions this one is replacing. Each link is id (hex-encoded 32 byte buffer) and index number, separated by '/'",
       "type": "array",
       "uniqueItems": true,
       "items": {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -2,7 +2,6 @@ import { ProtoTypes } from './proto/types.js'
 import {
   type MapeoDoc,
   type ProtoTypesWithSchemaInfo,
-  type VersionObj,
   type SchemaName,
   type DataTypeId,
   type ValidSchemaDef,
@@ -19,7 +18,7 @@ import {
 // @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants.js'
-import { getProtoTypeName } from './lib/utils.js'
+import { VersionIdObject, getProtoTypeName } from './lib/utils.js'
 
 /** Map of dataTypeIds to schema names for quick lookups */
 const dataTypeIdToSchemaName: Record<string, SchemaName> = {}
@@ -33,9 +32,9 @@ for (const [schemaName, dataTypeId] of Object.entries(dataTypeIds) as Array<
  * Decode a Buffer as an object validated against the corresponding schema
  *
  * @param buf Buffer to be decoded
- * @param versionObj public key (coreId) of the core where this block is stored, and the index (seq) of the block in the core.
+ * @param versionObj public key (coreKey) of the core where this block is stored, and the index of the block in the core.
  * */
-export function decode(buf: Buffer, versionObj: VersionObj): MapeoDoc {
+export function decode(buf: Buffer, versionObj: VersionIdObject): MapeoDoc {
   const schemaDef = decodeBlockPrefix(buf)
 
   const encodedMsg = buf.subarray(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ export { encode } from './encode.js'
 export { decode } from './decode.js'
 export { currentSchemaVersions } from './config.js'
 export { validate } from './validate.js'
+export {
+  getVersionId,
+  parseVersionId,
+  type VersionIdObject,
+} from './lib/utils.js'
 
 export * from './schema/index.js'
 export * from './schemas.js'

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -7,19 +7,19 @@ import {
 import {
   type MapeoDoc,
   type ProtoTypesWithSchemaInfo,
-  type VersionObj,
   type SchemaName,
   type FilterBySchemaName,
   type MapeoCommon,
   type TagValuePrimitive,
   type JsonTagValue,
 } from '../types.js'
+import { VersionIdObject, getVersionId } from './utils.js'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
 type ConvertFunction<TSchemaName extends SchemaName> = (
   message: Extract<ProtoTypesWithSchemaInfo, { schemaName: TSchemaName }>,
-  versionObj: VersionObj
+  versionObj: VersionIdObject
 ) => FilterBySchemaName<MapeoDoc, TSchemaName>
 
 export const convertProject: ConvertFunction<'project'> = (
@@ -172,7 +172,7 @@ function convertTagPrimitive({
 
 function convertCommon(
   common: ProtoTypesWithSchemaInfo['common'],
-  versionObj: VersionObj
+  versionObj: VersionIdObject
 ): Omit<MapeoCommon, 'schemaName'> {
   if (!common || !common.docId || !common.createdAt || !common.updatedAt) {
     throw new Error('Missing required common properties')
@@ -180,16 +180,9 @@ function convertCommon(
 
   return {
     docId: common.docId.toString('hex'),
-    versionId: versionObjToString(versionObj),
-    links: common.links.map(versionObjToString),
+    versionId: getVersionId(versionObj),
+    links: common.links.map((link) => getVersionId(link)),
     createdAt: common.createdAt,
     updatedAt: common.updatedAt,
   }
-}
-
-/**
- * Turn coreId and seq to a version string of ${hex-encoded coreId}/${seq}
- */
-function versionObjToString({ coreId, seq }: VersionObj) {
-  return `${coreId.toString('hex')}/${seq}`
 }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -6,11 +6,11 @@ import {
   MapeoCommon,
   TagValuePrimitive,
   JsonTagValue,
-  VersionObj,
   OmitUnion,
 } from '../types.js'
 import { TagValue_1, type TagValue_1_PrimitiveValue } from '../proto/tags/v1.js'
 import { Observation_5_Metadata } from '../proto/observation/v5.js'
+import { parseVersionId } from './utils.js'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
@@ -91,7 +91,7 @@ function convertCommon(
     docId: Buffer.from(common.docId, 'hex'),
     createdAt: common.createdAt,
     updatedAt: common.updatedAt,
-    links: common.links.map((link) => versionStringToObj(link)),
+    links: common.links.map((link) => parseVersionId(link)),
   }
 }
 
@@ -166,12 +166,4 @@ function convertTagPrimitive(
       const _exhaustiveCheck: never = tagPrimitive
   }
   return { kind }
-}
-
-/**
- * Turn a hex-encoded version string to a version objected with the coreId and index (seq)
- */
-function versionStringToObj(hexStr: string): VersionObj {
-  const [id, seq] = hexStr.split('/')
-  return { coreId: Buffer.from(id, 'hex'), seq: Number(seq) }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,36 @@ export function getProtoTypeName(schemaDef: ValidSchemaDef): ProtoTypeNames {
 function capitalize<T extends string>(str: T): Capitalize<T> {
   return (str.charAt(0).toUpperCase() + str.slice(1)) as any
 }
+
+export type VersionIdObject = {
+  coreKey: Buffer
+  index: number
+}
+
+/**
+ * Get a string versionId from a core key and index in that core. A versionId
+ * uniquely identifies a record in the underlying Hypercore storage used by
+ * Mapeo
+ * @param versionIdObject
+ * @returns versionId string
+ */
+export function getVersionId({ coreKey, index }: VersionIdObject) {
+  return coreKey.toString('hex') + '/' + index
+}
+
+/**
+ * Parse a versionId string to get the core key and index in that core. A
+ * versionId uniquely identifies a record in the underlying Hypercore storage
+ * used by Mapeo
+ * @param versionId hex-encoded 32-byte core key and index in the core, separated with `/`
+ * @returns coreKey as a Buffer and index in the core
+ */
+export function parseVersionId(versionId: string): VersionIdObject {
+  const items = versionId.split('/')
+  if (!items[0] || !items[1]) throw new Error('Invalid versionId')
+  const coreKey = Buffer.from(items[0], 'hex')
+  if (coreKey.length !== 32) throw new Error('Invalid versionId')
+  const index = Number.parseInt(items[1])
+  if (isNaN(index)) throw new Error('Invalid versionId')
+  return { coreKey, index }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,9 +33,6 @@ export type FilterBySchemaName<
   U extends string,
 > = Extract<T, { schemaName: U }>
 
-/** Uniquely identifies a block in a core */
-export type VersionObj = { coreId: Buffer; seq: number }
-
 /** Only proto types we currently support (whilst in dev) */
 export type ProtoTypesWithSchemaInfo = FilterBySchemaName<
   AllProtoTypesWithSchemaInfo,

--- a/test/index.js
+++ b/test/index.js
@@ -41,8 +41,8 @@ test('test validation of record', async (t) => {
   goodDocs.forEach((k) => {
     const doc = docs.good[k]
     const record = decode(encode(doc), {
-      coreId: randomBytes(32),
-      seq: 0,
+      coreKey: randomBytes(32),
+      index: 0,
     })
     t.doesNotThrow(() => {
       // field has a type which is different from the rest :|
@@ -56,8 +56,8 @@ test('test encoding, decoding of record and comparing the two versions', async (
   goodDocs.forEach((k) => {
     const doc = docs.good[k]
     const record = decode(encode(doc), {
-      coreId: randomBytes(32),
-      seq: 0,
+      coreKey: randomBytes(32),
+      index: 0,
     })
     const fields = Object.keys(doc)
     // t.plan(goodDocs.length * fields.length * 2)


### PR DESCRIPTION
Exports functions for parsing a string `versionId` to get the core key
and index, and for generating a string versionId. Also renames the
parameters: The naming convention of `seq` goes back many years to when
we used Hyperlog (precursor to Hypercore). `index` is the naming
currently used in Hypercore docs and I think it makes the most sense -
it refers to the index of the block within the hypercore. We also have a
convention in Mapeo Core of using `key` to refer to a Buffer, and `id`
to refer to a string. `docId` is the exception when named on the
protobuf, because it doesn't make sense to rename it when decoding, and
because `docId` as a string is never exposed outside this library.