### PR TITLE
make project schema properties optional

### DIFF
--- a/proto/project/v1.proto
+++ b/proto/project/v1.proto
@@ -20,7 +20,7 @@ message Project_1 {
     repeated bytes relation = 5;
   };
 
-  DefaultPresets defaultPresets = 2;
+  optional DefaultPresets defaultPresets = 2;
 
-  string name = 5;
+  optional string name = 5;
 }

--- a/proto/project/v2.proto
+++ b/proto/project/v2.proto
@@ -22,7 +22,7 @@ message Project_2 {
     repeated bytes relation = 5;
   };
 
-  DefaultPresets defaultPresets = 2;
+  optional DefaultPresets defaultPresets = 2;
 
-  string name = 5;
+  optional string name = 5;
 }

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -13,15 +13,17 @@
       "description": "name of the project",
       "type": "string"
     },
-    "defaultPresets":{
+    "defaultPresets": {
       "type": "object",
       "properties": {
-        "point": { "type": "array", "items":{"type":"string"}},
-        "area": { "type": "array", "items":{"type":"string"}},
-        "vertex": { "type": "array", "items":{"type":"string"}},
-        "line": { "type": "array", "items":{"type":"string"}},
-        "relation": { "type": "array", "items":{"type":"string"}}
-      }
+        "point": { "type": "array", "items": { "type": "string" } },
+        "area": { "type": "array", "items": { "type": "string" } },
+        "vertex": { "type": "array", "items": { "type": "string" } },
+        "line": { "type": "array", "items": { "type": "string" } },
+        "relation": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["point", "area", "vertex", "line", "relation"],
+      "additionalProperties": false
     }
   },
   "required": ["schemaName"],

--- a/schema/project/v1.json
+++ b/schema/project/v1.json
@@ -24,6 +24,6 @@
       }
     }
   },
-  "required": ["schemaName", "name", "defaultPresets"],
+  "required": ["schemaName"],
   "additionalProperties": false
 }

--- a/schema/project/v2.json
+++ b/schema/project/v2.json
@@ -24,6 +24,6 @@
       }
     }
   },
-  "required": ["schemaName", "name", "defaultPresets"],
+  "required": ["schemaName"],
   "additionalProperties": false
 }

--- a/schema/project/v2.json
+++ b/schema/project/v2.json
@@ -16,12 +16,14 @@
     "defaultPresets": {
       "type": "object",
       "properties": {
-        "point": { "type": "array", "items":{"type":"string"}},
-        "area": { "type": "array", "items":{"type":"string"}},
-        "vertex": { "type": "array", "items":{"type":"string"}},
-        "line": { "type": "array", "items":{"type":"string"}},
-        "relation": { "type": "array", "items":{"type":"string"}}
-      }
+        "point": { "type": "array", "items": { "type": "string" } },
+        "area": { "type": "array", "items": { "type": "string" } },
+        "vertex": { "type": "array", "items": { "type": "string" } },
+        "line": { "type": "array", "items": { "type": "string" } },
+        "relation": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["point", "area", "vertex", "line", "relation"],
+      "additionalProperties": false
     }
   },
   "required": ["schemaName"],

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -237,12 +237,3 @@ function convertCommon(
     updatedAt: common.updatedAt,
   }
 }
-
-/**
- * Unsafe type for Object.entries - you must be sure that the object does not
-   have additional properties that are not defined in the type, e.g. when using
-   a const value
- */
-export type Entries<T> = {
-  [K in keyof T]: [K, T[K]]
-}[keyof T][]

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -26,18 +26,20 @@ export const convertProject: ConvertFunction<'project'> = (
   message,
   versionObj
 ) => {
-  const { common, schemaVersion, ...rest } = message
+  const { common, schemaVersion, defaultPresets, ...rest } = message
   const jsonSchemaCommon = convertCommon(common, versionObj)
   return {
     ...jsonSchemaCommon,
     ...rest,
-    defaultPresets: {
-      point: message.defaultPresets?.point.map((p) => p.toString('hex')),
-      area: message.defaultPresets?.area.map((a) => a.toString('hex')),
-      vertex: message.defaultPresets?.vertex.map((v) => v.toString('hex')),
-      line: message.defaultPresets?.line.map((l) => l.toString('hex')),
-      relation: message.defaultPresets?.relation.map((r) => r.toString('hex')),
-    },
+    defaultPresets: defaultPresets
+      ? {
+          point: defaultPresets.point.map((p) => p.toString('hex')),
+          area: defaultPresets.area.map((a) => a.toString('hex')),
+          vertex: defaultPresets.vertex.map((v) => v.toString('hex')),
+          line: defaultPresets.line.map((l) => l.toString('hex')),
+          relation: defaultPresets.relation.map((r) => r.toString('hex')),
+        }
+      : undefined,
   }
 }
 
@@ -235,3 +237,12 @@ function convertCommon(
     updatedAt: common.updatedAt,
   }
 }
+
+/**
+ * Unsafe type for Object.entries - you must be sure that the object does not
+   have additional properties that are not defined in the type, e.g. when using
+   a const value
+ */
+export type Entries<T> = {
+  [K in keyof T]: [K, T[K]]
+}[keyof T][]

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -21,28 +21,29 @@ type ConvertFunction<TSchemaName extends SchemaName> = (
   >
 ) => CurrentProtoTypes[TSchemaName]
 
-/* @ts-ignore TODO: resolve "not assignable to type 'ConvertFunction<"project">" */
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
-    defaultPresets: {
-      point: (mapeoDoc.defaultPresets?.point || []).map((p) =>
-        Buffer.from(p, 'hex')
-      ),
-      area: (mapeoDoc.defaultPresets?.area || []).map((a) =>
-        Buffer.from(a, 'hex')
-      ),
-      vertex: (mapeoDoc.defaultPresets?.vertex || []).map((v) =>
-        Buffer.from(v, 'hex')
-      ),
-      line: (mapeoDoc.defaultPresets?.line || []).map((l) =>
-        Buffer.from(l, 'hex')
-      ),
-      relation: (mapeoDoc.defaultPresets?.relation || []).map((r) =>
-        Buffer.from(r, 'hex')
-      ),
-    },
+    defaultPresets: mapeoDoc.defaultPresets
+      ? {
+          point: (mapeoDoc.defaultPresets.point || []).map((p) =>
+            Buffer.from(p, 'hex')
+          ),
+          area: (mapeoDoc.defaultPresets.area || []).map((a) =>
+            Buffer.from(a, 'hex')
+          ),
+          vertex: (mapeoDoc.defaultPresets.vertex || []).map((v) =>
+            Buffer.from(v, 'hex')
+          ),
+          line: (mapeoDoc.defaultPresets.line || []).map((l) =>
+            Buffer.from(l, 'hex')
+          ),
+          relation: (mapeoDoc.defaultPresets.relation || []).map((r) =>
+            Buffer.from(r, 'hex')
+          ),
+        }
+      : undefined,
   }
 }
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -22,26 +22,17 @@ type ConvertFunction<TSchemaName extends SchemaName> = (
 ) => CurrentProtoTypes[TSchemaName]
 
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
+  const { defaultPresets } = mapeoDoc
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
-    defaultPresets: mapeoDoc.defaultPresets
+    defaultPresets: defaultPresets
       ? {
-          point: (mapeoDoc.defaultPresets.point || []).map((p) =>
-            Buffer.from(p, 'hex')
-          ),
-          area: (mapeoDoc.defaultPresets.area || []).map((a) =>
-            Buffer.from(a, 'hex')
-          ),
-          vertex: (mapeoDoc.defaultPresets.vertex || []).map((v) =>
-            Buffer.from(v, 'hex')
-          ),
-          line: (mapeoDoc.defaultPresets.line || []).map((l) =>
-            Buffer.from(l, 'hex')
-          ),
-          relation: (mapeoDoc.defaultPresets.relation || []).map((r) =>
-            Buffer.from(r, 'hex')
-          ),
+          point: defaultPresets.point.map((p) => Buffer.from(p, 'hex')),
+          area: defaultPresets.area.map((a) => Buffer.from(a, 'hex')),
+          vertex: defaultPresets.vertex.map((v) => Buffer.from(v, 'hex')),
+          line: defaultPresets.line.map((l) => Buffer.from(l, 'hex')),
+          relation: defaultPresets.relation.map((r) => Buffer.from(r, 'hex')),
         }
       : undefined,
   }

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -21,24 +21,25 @@ type ConvertFunction<TSchemaName extends SchemaName> = (
   >
 ) => CurrentProtoTypes[TSchemaName]
 
+/* @ts-ignore TODO: resolve "not assignable to type 'ConvertFunction<"project">" */
 export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
     defaultPresets: {
-      point: (mapeoDoc.defaultPresets.point || []).map((p) =>
+      point: (mapeoDoc.defaultPresets?.point || []).map((p) =>
         Buffer.from(p, 'hex')
       ),
-      area: (mapeoDoc.defaultPresets.area || []).map((a) =>
+      area: (mapeoDoc.defaultPresets?.area || []).map((a) =>
         Buffer.from(a, 'hex')
       ),
-      vertex: (mapeoDoc.defaultPresets.vertex || []).map((v) =>
+      vertex: (mapeoDoc.defaultPresets?.vertex || []).map((v) =>
         Buffer.from(v, 'hex')
       ),
-      line: (mapeoDoc.defaultPresets.line || []).map((l) =>
+      line: (mapeoDoc.defaultPresets?.line || []).map((l) =>
         Buffer.from(l, 'hex')
       ),
-      relation: (mapeoDoc.defaultPresets.relation || []).map((r) =>
+      relation: (mapeoDoc.defaultPresets?.relation || []).map((r) =>
         Buffer.from(r, 'hex')
       ),
     },

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -34,18 +34,8 @@ export const goodDocsMinimal = [
       createdAt: cachedValues.createdAt,
       updatedAt: cachedValues.updatedAt,
       links: [],
-      defaultPresets: {},
-      name: 'myProject',
     },
-    expected: {
-      defaultPresets: {
-        point: [],
-        area: [],
-        vertex: [],
-        line: [],
-        relation: [],
-      },
-    },
+    expected: {},
   },
   {
     doc: {


### PR DESCRIPTION
This removes `name` and `defaultPresets` from the required array of the project jsonschemas.

There's one type error that I've ts-ignored that I'm not sure how to deal with. See the comment below.