### PR TITLE
feat: rename project -> projectSettings

### DIFF
--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -5,10 +5,10 @@ import "google/protobuf/timestamp.proto";
 import "common/v1.proto";
 import "options.proto";
 
-message Project_1 {
+message ProjectSettings_1 {
   // **DO NOT CHANGE dataTypeId** generated with `openssl rand -hex 6`
   option (dataTypeId) = "626b45fe2942";
-  option (schemaName) = "project";
+  option (schemaName) = "projectSettings";
 
   Common_1 common = 1;
 

--- a/proto/projectSettings/v2.proto
+++ b/proto/projectSettings/v2.proto
@@ -7,10 +7,10 @@ import "options.proto";
 
 // Same as v1, created to test forward compatibility
 
-message Project_2 {
+message ProjectSettings_2 {
   // **DO NOT CHANGE dataTypeId** generated with `openssl rand -hex 6`
   option (dataTypeId) = "626b45fe2942";
-  option (schemaName) = "project";
+  option (schemaName) = "projectSettings";
 
   Common_1 common = 1;
 

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://mapeo.world/schemas/project/v1.json",
-  "title": "Project",
+  "title": "ProjectSettings",
   "type": "object",
   "properties": {
     "schemaName": {
       "description": "Must be `project`",
       "type": "string",
-      "const": "project"
+      "const": "projectSettings"
     },
     "name": {
       "description": "name of the project",

--- a/schema/projectSettings/v2.json
+++ b/schema/projectSettings/v2.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://mapeo.world/schemas/project/v1.json",
-  "title": "Project",
+  "title": "ProjectSettings",
   "type": "object",
   "properties": {
     "schemaName": {
       "description": "Must be `project`",
       "type": "string",
-      "const": "project"
+      "const": "projectSettings"
     },
     "name": {
       "description": "name of the project",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -10,7 +10,7 @@ import {
 import { Decode } from './proto/index.js'
 import { dataTypeIds, knownSchemaVersions } from './config.js'
 import {
-  convertProject,
+  convertProjectSettings,
   convertField,
   convertObservation,
   convertPreset,
@@ -54,8 +54,8 @@ export function decode(
   const message = mutatingSetSchemaDef(messageWithoutSchemaInfo, schemaDef)
 
   switch (message.schemaName) {
-    case 'project':
-      return convertProject(message, versionObj)
+    case 'projectSettings':
+      return convertProjectSettings(message, versionObj)
     case 'observation':
       return convertObservation(message, versionObj)
     case 'field':

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -13,7 +13,7 @@ import {
   convertField,
   convertObservation,
   convertPreset,
-  convertProject,
+  convertProjectSettings,
   convertRole,
   convertDeviceInfo,
   convertCoreOwnership,
@@ -47,8 +47,8 @@ export function encode(
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }
-    case 'project': {
-      const message = convertProject(mapeoDoc)
+    case 'projectSettings': {
+      const message = convertProjectSettings(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -23,7 +23,7 @@ type ConvertFunction<TSchemaName extends SchemaName> = (
   versionObj: VersionIdObject
 ) => FilterBySchemaName<MapeoDocInternal, TSchemaName>
 
-export const convertProject: ConvertFunction<'project'> = (
+export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
   message,
   versionObj
 ) => {

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -23,7 +23,9 @@ type ConvertFunction<TSchemaName extends SchemaName> = (
   >
 ) => CurrentProtoTypes[TSchemaName]
 
-export const convertProject: ConvertFunction<'project'> = (mapeoDoc) => {
+export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
+  mapeoDoc
+) => {
   const { defaultPresets } = mapeoDoc
   return {
     common: convertCommon(mapeoDoc),

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import { dataTypeIds } from './config.js'
 
 /** Temporary: once we have completed this module everything should be supported */
 type SupportedSchemaNames =
-  | 'project'
+  | 'projectSettings'
   | 'observation'
   | 'field'
   | 'preset'

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -71,7 +71,7 @@ export const goodDocsCompleted = [
     doc: {
       docId: cachedValues.docId,
       versionId: cachedValues.versionId,
-      schemaName: 'project',
+      schemaName: 'projectSettings',
       createdAt: cachedValues.createdAt,
       updatedAt: cachedValues.updatedAt,
       links: [],

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -30,7 +30,7 @@ export const goodDocsMinimal = [
     doc: {
       docId: cachedValues.docId,
       versionId: cachedValues.versionId,
-      schemaName: 'project',
+      schemaName: 'projectSettings',
       createdAt: cachedValues.createdAt,
       updatedAt: cachedValues.updatedAt,
       links: [],


### PR DESCRIPTION
Fixes #114 

Chose `projectSettings` since it seems the most gramatically correct. Shouldn't need to worry about the plural, because we're not pluralizing table names, partly for this reason.