### PR TITLE
fix: export MapeoDocInternal type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export {
 
 export * from './schema/index.js'
 export * from './schemas.js'
+export { type MapeoDocInternal } from './types.js'


### PR DESCRIPTION
This type is not exposed in the public API, but it is needed
for internal use in @mapeo/core (checking signatures)