### PR TITLE
feat: header tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { encode, encodeBlockPrefix } from './encode.js'
+export { encode } from './encode.js'
 export { decode, decodeBlockPrefix } from './decode.js'
 export { currentSchemaVersions } from './config.js'
 export { validate } from './validate.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { encode } from './encode.js'
+export { encode, encodeBlockPrefix } from './encode.js'
 export { decode, decodeBlockPrefix } from './decode.js'
 export { currentSchemaVersions } from './config.js'
 export { validate } from './validate.js'

--- a/test/index.js
+++ b/test/index.js
@@ -70,7 +70,6 @@ then decoding and comparing the two objects - extra values shouldn't be present`
 })
 
 test(`testing decoding of header that should match the dataTypeId and version`, async (t) => {
-  t.plan(Object.values(dataTypeIds).length * 2)
   for (const [schemaName, dataTypeId] of Object.entries(dataTypeIds)) {
     // TODO: test also schemaVersions greater than the current, for foward compat
     const schemaVersion = currentSchemaVersions[schemaName]
@@ -91,7 +90,6 @@ test(`testing decoding of header that should match the dataTypeId and version`, 
 })
 
 test(`test encoding and decoding of block prefix, ignoring data that comes after`, async (t) => {
-  t.plan(Object.keys(currentSchemaVersions).length * 2)
   for (let [schemaName, schemaVersion] of Object.entries(
     currentSchemaVersions
   )) {
@@ -117,7 +115,6 @@ test(`test encoding and decoding of block prefix, ignoring data that comes after
 })
 
 test(`test encoding of wrongly formatted header`, async (t) => {
-  t.plan(4)
   /** @type { import('../src/types.js').ValidSchemaDef } */
   let schemaDef = {
     schemaName: 'presot',

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,6 @@ import {
   goodDocsCompleted,
   badDocs,
 } from './fixtures/index.js'
-import { throws } from 'node:assert'
 
 test('Bad docs throw when encoding', (t) => {
   for (const { text, doc } of badDocs) {
@@ -156,7 +155,7 @@ test(`test encoding of wrongly formatted header`, async (t) => {
   // hardcoded since there's a slim chance we produce a correct header
   const unknownDataTypeId = Buffer.from('7a79b8b773b2', 'hex')
   unknownDataTypeId.copy(buf)
-  throws(() => {
+  t.throws(() => {
     decodeBlockPrefix(buf)
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ import {
 import { encodeBlockPrefix } from '../dist/encode.js'
 import { dataTypeIds, currentSchemaVersions } from '../dist/config.js'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from '../dist/constants.js'
-import * as cenc from 'compact-encoding'
 import {
   goodDocsMinimal,
   goodDocsCompleted,

--- a/test/index.js
+++ b/test/index.js
@@ -105,14 +105,10 @@ test(`testing decoding of header that should match the dataTypeId and version`, 
 
 test(`test failing of decoding when scrambling the header`, async (t) => {
   for (const { doc } of goodDocsCompleted) {
-    const buffer = encode(doc)
+    const buffer = encode(doc).sort(() => 0.5 - Math.random())
     /** @type {Buffer} */
-    const newBuf = buffer.map(() => {
-      const newIdx = Math.floor(Math.random() * buffer.length)
-      return buffer[newIdx]
-    })
     t.throws(() => {
-      decode(newBuf, parseVersionId(doc.versionId))
+      decode(buffer, parseVersionId(doc.versionId))
     }, `failing on decoding ${doc.schemaName}`)
   }
 })

--- a/test/index.js
+++ b/test/index.js
@@ -92,16 +92,6 @@ test(`testing decoding of header that should match the dataTypeId and version`, 
   }
 })
 
-test(`test failing of decoding when scrambling the header`, async (t) => {
-  for (const { doc } of goodDocsCompleted) {
-    const buffer = encode(doc).sort(() => 0.5 - Math.random())
-    /** @type {Buffer} */
-    t.throws(() => {
-      decode(buffer, parseVersionId(doc.versionId))
-    }, `failing on decoding ${doc.schemaName}`)
-  }
-})
-
 test(`test encoding and decoding of block prefix, ignoring data that comes after`, async (t) => {
   t.plan(Object.keys(currentSchemaVersions).length * 2)
   for (let [schemaName, schemaVersion] of Object.entries(
@@ -149,8 +139,13 @@ test(`test encoding of wrongly formatted header`, async (t) => {
     decodeBlockPrefix(buf)
   }, `when decoding a header with the wrong length`)
 
+  // hardcoded since there's a slim chance we produce a correct header
+  const randomBuf = Buffer.from(
+    '806a8dbb56e1994c8ea6887cda1d21b441eb9122',
+    'hex'
+  )
   t.throws(() => {
-    decodeBlockPrefix(randomBytes(20))
+    decodeBlockPrefix(randomBuf)
   }, `when trying to decode a header that is random data`)
 
   t.throws(() => {
@@ -159,7 +154,8 @@ test(`test encoding of wrongly formatted header`, async (t) => {
 
   schemaDef = { schemaName: 'projectSettings', schemaVersion: 2 }
   buf = encodeBlockPrefix(schemaDef)
-  const unknownDataTypeId = randomBytes(DATA_TYPE_ID_BYTES)
+  // hardcoded since there's a slim chance we produce a correct header
+  const unknownDataTypeId = Buffer.from('7a79b8b773b2', 'hex')
   unknownDataTypeId.copy(buf)
   throws(() => {
     decodeBlockPrefix(buf)


### PR DESCRIPTION
This adds some tests for encoding the headers of a `MapeoDoc`.
Additionally I've added an export for `encodingBlockPrefix` only to be accessible from the unit test.

This should close #123 