### PR TITLE
add hash in attachments to observation schema

### DIFF
--- a/proto/observation/v5.proto
+++ b/proto/observation/v5.proto
@@ -32,7 +32,7 @@ message Observation_5 {
     bytes driveId = 1;
     string name = 2;
     AttachmentType type = 3;
-    string hash = 4;
+    bytes hash = 4;
   }
   repeated Attachment attachments = 8;
 

--- a/proto/observation/v5.proto
+++ b/proto/observation/v5.proto
@@ -32,6 +32,7 @@ message Observation_5 {
     bytes driveId = 1;
     string name = 2;
     AttachmentType type = 3;
+    string hash = 4;
   }
   repeated Attachment attachments = 8;
 

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -106,7 +106,7 @@
             "description": "SHA256 hash of the attachment"
           }
         },
-        "required": ["driveId", "name", "type"]
+        "required": ["driveId", "name", "type", "hash"]
       }
     },
     "tags": {

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -100,6 +100,10 @@
               "UNRECOGNIZED": "future attachment type"
             },
             "enum": ["photo", "video", "audio", "UNRECOGNIZED"]
+          },
+          "hash": {
+            "type": "string",
+            "description": "SHA256 hash of the attachment"
           }
         },
         "required": ["driveId", "name", "type"]

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -55,8 +55,8 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...jsonSchemaCommon,
     ...rest,
     refs: message.refs?.map(({ id }) => ({ id: id.toString('hex') })),
-    attachments: message.attachments?.map(({ driveId, name, type }) => {
-      return { driveId: driveId.toString('hex'), name, type }
+    attachments: message.attachments?.map(({ driveId, name, type, hash }) => {
+      return { driveId: driveId.toString('hex'), name, type, hash }
     }),
     tags: convertTags(message.tags),
     metadata: message.metadata || {},

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -56,7 +56,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...rest,
     refs: message.refs?.map(({ id }) => ({ id: id.toString('hex') })),
     attachments: message.attachments?.map(({ driveId, name, type, hash }) => {
-      return { driveId: driveId.toString('hex'), name, type, hash }
+      return { driveId: driveId.toString('hex'), name, type, hash: hash.toString('hex') }
     }),
     tags: convertTags(message.tags),
     metadata: message.metadata || {},

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -83,7 +83,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
       driveId: Buffer.from(attachment.driveId, 'hex'),
       name: attachment.name,
       type: attachment.type,
-      hash: attachment.hash,
+      hash: Buffer.from(attachment.hash, 'hex'),
     }
   })
 

--- a/src/lib/encode-converstions.ts
+++ b/src/lib/encode-converstions.ts
@@ -83,6 +83,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
       driveId: Buffer.from(attachment.driveId, 'hex'),
       name: attachment.name,
       type: attachment.type,
+      hash: attachment.hash,
     }
   })
 

--- a/test/fixtures/cached.js
+++ b/test/fixtures/cached.js
@@ -10,7 +10,10 @@ export const cachedValues = {
   coreId: randomBytes(32).toString('hex'),
   createdAt: date,
   updatedAt: date,
-  attachments: { driveId: randomBytes(32).toString('hex') },
+  attachments: {
+    driveId: randomBytes(32).toString('hex'),
+    hash: randomBytes(32).toString('hex'),
+  },
   metadata: {
     position: {
       timestamp: date,

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -25,6 +25,7 @@ export const goodDocsCompleted = [
           name: 'myFile',
           type: 'photo',
           driveId: cachedValues.attachments.driveId,
+          hash: cachedValues.attachments.hash,
         },
       ],
       tags: {


### PR DESCRIPTION
A change to the observation schema to support digidem/mapeo-core-next#220.