### PR TITLE
chore!: rename Attachment.driveId to Attachment.driveDiscoveryId

### DIFF
--- a/proto/observation/v5.proto
+++ b/proto/observation/v5.proto
@@ -29,7 +29,7 @@ message Observation_5 {
     audio = 2;
   }
   message Attachment {
-    bytes driveId = 1;
+    bytes driveDiscoveryId = 1;
     string name = 2;
     AttachmentType type = 3;
     bytes hash = 4;

--- a/schema/observation/v5.json
+++ b/schema/observation/v5.json
@@ -85,9 +85,9 @@
       "items": {
         "type": "object",
         "properties": {
-          "driveId": {
+          "driveDiscoveryId": {
             "type": "string",
-            "description": ""
+            "description": "core discovery id for the drive that the attachment belongs to"
           },
           "name": {
             "type": "string",
@@ -106,7 +106,7 @@
             "description": "SHA256 hash of the attachment"
           }
         },
-        "required": ["driveId", "name", "type", "hash"]
+        "required": ["driveDiscoveryId", "name", "type", "hash"]
       }
     },
     "tags": {

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -55,14 +55,16 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...jsonSchemaCommon,
     ...rest,
     refs: message.refs?.map(({ id }) => ({ id: id.toString('hex') })),
-    attachments: message.attachments?.map(({ driveId, name, type, hash }) => {
-      return {
-        driveId: driveId.toString('hex'),
-        name,
-        type,
-        hash: hash.toString('hex'),
+    attachments: message.attachments?.map(
+      ({ driveDiscoveryId, name, type, hash }) => {
+        return {
+          driveDiscoveryId: driveDiscoveryId.toString('hex'),
+          name,
+          type,
+          hash: hash.toString('hex'),
+        }
       }
-    }),
+    ),
     tags: convertTags(message.tags),
     metadata: message.metadata || {},
   }

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -80,7 +80,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
   })
   const attachments = mapeoDoc.attachments.map((attachment) => {
     return {
-      driveId: Buffer.from(attachment.driveId, 'hex'),
+      driveDiscoveryId: Buffer.from(attachment.driveDiscoveryId, 'hex'),
       name: attachment.name,
       type: attachment.type,
       hash: Buffer.from(attachment.hash, 'hex'),

--- a/test/fixtures/cached.js
+++ b/test/fixtures/cached.js
@@ -12,7 +12,7 @@ export const cachedValues = {
   createdAt: date,
   updatedAt: date,
   attachments: {
-    driveId: randomBytes(32).toString('hex'),
+    driveDiscoveryId: randomBytes(32).toString('hex'),
     hash: randomBytes(32).toString('hex'),
   },
   metadata: {

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -25,7 +25,7 @@ export const goodDocsCompleted = [
         {
           name: 'myFile',
           type: 'photo',
-          driveId: cachedValues.attachments.driveId,
+          driveDiscoveryId: cachedValues.attachments.driveDiscoveryId,
           hash: cachedValues.attachments.hash,
         },
       ],


### PR DESCRIPTION
Towards https://github.com/digidem/mapeo-core-next/issues/272

My understanding from the issue is that we want to rename this, but not entirely sure 😄 