### PR TITLE
fix: address naming inconsitencies with the DeviceInfo json schema definition

### DIFF
--- a/schema/deviceInfo/v1.json
+++ b/schema/deviceInfo/v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://mapeo.world/schemas/device/v1.json",
-  "title": "Device Info",
+  "title": "DeviceInfo",
   "type": "object",
   "properties": {
     "schemaName": {

--- a/schema/deviceInfo/v1.json
+++ b/schema/deviceInfo/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://mapeo.world/schemas/device/v1.json",
+  "$id": "http://mapeo.world/schemas/deviceInfo/v1.json",
   "title": "DeviceInfo",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Updates the following:

- Updates `$id` field to include full name e.g. `deviceInfo`, not `device`
- Updates `title` field to use pascal casing like other multi-worded schema defs we have
