### PR TITLE
feat: Expose validation errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { validate } from './validate.js'
 export {
   getVersionId,
   parseVersionId,
+  valueOf,
   type VersionIdObject,
 } from './lib/utils.js'
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,10 @@
 import { type ProtoTypeNames } from '../proto/types.js'
-import { type ValidSchemaDef } from '../types.js'
+import {
+  type ValidSchemaDef,
+  type MapeoDoc,
+  type MapeoValue,
+  type FilterBySchemaName,
+} from '../types.js'
 
 export class ExhaustivenessError extends Error {
   constructor(value: never) {
@@ -52,4 +57,28 @@ export function parseVersionId(versionId: string): VersionIdObject {
   const index = Number.parseInt(items[1])
   if (isNaN(index)) throw new Error('Invalid versionId')
   return { coreDiscoveryKey, index }
+}
+
+/**
+ * @template {import('@mapeo/schema').MapeoDoc & { forks?: string[] }} T
+ * @param {T} doc
+ * @returns {Omit<T, 'docId' | 'versionId' | 'links' | 'forks' | 'createdAt' | 'updatedAt' | 'createdBy' | 'deleted'>}
+ */
+export function valueOf<TDoc extends MapeoDoc>(
+  doc: TDoc & { forks?: string[] }
+): FilterBySchemaName<MapeoValue, TDoc['schemaName']> {
+  /* eslint-disable no-unused-vars */
+  const {
+    docId,
+    versionId,
+    links,
+    forks,
+    createdAt,
+    updatedAt,
+    createdBy,
+    deleted,
+    ...rest
+  } = doc
+  /* eslint-enable no-unused-vars */
+  return rest as any
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,11 +1,29 @@
 import { MapeoValue, FilterBySchemaName, SchemaName } from './types.js'
 import * as validations from './validations.js'
+import {
+  type ValidateFunction as AjvValidateFunction,
+  type DefinedError,
+} from 'ajv'
 
-export function validate<
+interface ValidateFunction {
+  <TSchemaName extends Extract<keyof typeof validations, SchemaName>>(
+    schemaName: TSchemaName,
+    obj: unknown
+  ): obj is FilterBySchemaName<MapeoValue, TSchemaName>
+  errors: null | DefinedError[]
+}
+
+const validate: ValidateFunction = <
   TSchemaName extends Extract<keyof typeof validations, SchemaName>,
 >(
   schemaName: TSchemaName,
   obj: unknown
-): obj is FilterBySchemaName<MapeoValue, TSchemaName> {
-  return validations[schemaName](obj)
+): obj is FilterBySchemaName<MapeoValue, TSchemaName> => {
+  const validateSchema = validations[schemaName] as AjvValidateFunction
+  const result = validateSchema(obj)
+  validate.errors = validateSchema.errors as DefinedError[]
+  return result
 }
+validate.errors = null
+
+export { validate }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,10 @@ import {
   decode,
   decodeBlockPrefix,
   parseVersionId,
+  validate,
+  valueOf,
 } from '../dist/index.js'
+
 import { encodeBlockPrefix } from '../dist/encode.js'
 import { dataTypeIds, currentSchemaVersions } from '../dist/config.js'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from '../dist/constants.js'
@@ -23,6 +26,37 @@ test('Bad docs throw when encoding', () => {
       // @ts-expect-error
       encode(doc)
     }, text)
+  }
+})
+
+test('validate bad docs', () => {
+  for (const schemaName of Object.keys(currentSchemaVersions)) {
+    assert(
+      // @ts-ignore
+      !validate(schemaName, {}),
+      `${schemaName} with missing properties should not validate`
+    )
+    assert(
+      Array.isArray(validate.errors),
+      'validate.errors should be an array after failed validation'
+    )
+    assert.equal(
+      validate.errors.length,
+      1,
+      'validate.errors should have one error'
+    )
+  }
+})
+
+test('validate good docs', () => {
+  for (const { doc, expected } of [...goodDocsMinimal, ...goodDocsCompleted]) {
+    // skip docs with UNRECOGNIZED values - these are used for testing encoding/decoding and will not validate (the decoded versions should validate)
+    if (Object.values(expected).includes('UNRECOGNIZED')) continue
+    assert(
+      // @ts-ignore
+      validate(doc.schemaName, valueOf(doc)),
+      `${doc.schemaName} with all required properties should validate`
+    )
   }
 })
 


### PR DESCRIPTION
Exposes validation errors as an array on the `validate()` function, like Ajv does.


Also adds an export of the `valueOf` utility, which can replace the version used in mapeo-core-next.