### PR TITLE
feat: Add track schema type

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -9,7 +9,7 @@ plugins:
       - importSuffix=.js
       - env=node
       - snakeToCamel=false
-      - useDate=string
+      - useDate=false
       # - useOptionals=none
       - stringEnums=true
       - enumsAsLiterals=true

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -9,7 +9,7 @@ plugins:
       - importSuffix=.js
       - env=node
       - snakeToCamel=false
-      - useDate=false
+      - useDate=string
       # - useOptionals=none
       - stringEnums=true
       - enumsAsLiterals=true

--- a/proto/track/v1.proto
+++ b/proto/track/v1.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+package mapeo;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/struct.proto";
+import "tags/v1.proto";
+import "common/v1.proto";
+import "options.proto";
+
+message Track_1 {
+  // **DO NOT CHANGE dataTypeId** generated with `openssl rand -hex 6`
+  option (dataTypeId) = "1e353f7ba641";
+  option (schemaName) = "track";
+
+  Common_1 common = 1;
+  repeated Position locations = 2;
+  repeated Ref refs = 3;
+  repeated Attachment attachments = 4;
+  map<string, TagValue_1> tags = 5;
+
+  enum RefType {
+    observation = 0;
+  }
+  message Ref {
+    bytes id = 1;
+    RefType type = 2;
+  }
+
+  enum AttachmentType {
+    photo = 0;
+    video = 1;
+    audio = 2;
+  }
+  message Attachment {
+    bytes driveDiscoveryId = 1;
+    string name = 2;
+    AttachmentType type = 3;
+    bytes hash = 4;
+  }
+
+  message Position {
+    google.protobuf.Timestamp timestamp = 1;
+    bool mocked = 2;
+
+    message Coords {
+      double latitude = 1;
+      double longitude = 2;
+      optional double altitude = 3;
+      optional double heading = 4;
+      optional double speed = 5;
+      optional double accuracy = 6;
+    }
+
+    Coords coords = 3;
+  }
+}

--- a/schema/track/v1.json
+++ b/schema/track/v1.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://mapeo.world/schemas/track/v1.json",
+  "title": "Track",
+  "description": "A track is a recording of positions over time, with associated tags and attachments, similar to an observation",
+  "definitions": {
+    "position": {
+      "description": "Position details",
+      "type": "object",
+      "required": ["timestamp", "mocked", "coords"],
+      "properties": {
+        "timestamp": {
+          "description": "Timestamp (milliseconds since UNIX epoch) of when the current position was obtained",
+          "type": "number"
+        },
+        "mocked": {
+          "description": "`true` if the position was mocked",
+          "type": "boolean",
+          "default": false
+        },
+        "coords": {
+          "description": "Position details, should be self explanatory. Units in meters",
+          "type": "object",
+          "required": ["latitude", "longitude"],
+          "properties": {
+            "latitude": {
+              "type": "number"
+            },
+            "longitude": {
+              "type": "number"
+            },
+            "altitude": {
+              "type": "number"
+            },
+            "heading": {
+              "type": "number"
+            },
+            "speed": {
+              "type": "number"
+            },
+            "accuracy": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "schemaName": {
+      "description": "Must be `track`",
+      "type": "string",
+      "const": "track"
+    },
+    "locations": {
+      "type": "array",
+      "description": "Array of positions along the track",
+      "items": {
+        "$ref": "#/definitions/position"
+      }
+    },
+    "refs": {
+      "type": "array",
+      "description": "References to any observations that this track is related to.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "hex-encoded id of the element that this track references",
+            "type": "string"
+          },
+          "type": {
+            "description": "type of the element that this track references",
+            "type": "string",
+            "enum": ["observation", "UNRECOGNIZED"],
+            "meta:enum": {
+              "UNRECOGNIZED": "future reference type"
+            }
+          }
+        },
+        "required": ["id", "type"]
+      }
+    },
+    "attachments": {
+      "type": "array",
+      "description": "media or other data that are attached to this observation",
+      "items": {
+        "type": "object",
+        "properties": {
+          "driveDiscoveryId": {
+            "type": "string",
+            "description": "core discovery id for the drive that the attachment belongs to"
+          },
+          "name": {
+            "type": "string",
+            "description": "name of the attachment"
+          },
+          "type": {
+            "type": "string",
+            "description": "string that describes the type of the attachment",
+            "meta:enum": {
+              "UNRECOGNIZED": "future attachment type"
+            },
+            "enum": ["photo", "video", "audio", "UNRECOGNIZED"]
+          },
+          "hash": {
+            "type": "string",
+            "description": "SHA256 hash of the attachment"
+          }
+        },
+        "required": ["driveDiscoveryId", "name", "type", "hash"]
+      }
+    },
+    "tags": {
+      "type": "object",
+      "description": "User-defined key-value pairs relevant to this track",
+      "properties": {},
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "required": ["schemaName", "locations", "tags", "refs", "attachments"],
+  "additionalProperties": false
+}

--- a/schema/track/v1.json
+++ b/schema/track/v1.json
@@ -85,7 +85,7 @@
     },
     "attachments": {
       "type": "array",
-      "description": "media or other data that are attached to this observation",
+      "description": "media or other data that are attached to this track",
       "items": {
         "type": "object",
         "properties": {

--- a/schema/track/v1.json
+++ b/schema/track/v1.json
@@ -10,8 +10,9 @@
       "required": ["timestamp", "mocked", "coords"],
       "properties": {
         "timestamp": {
-          "description": "Timestamp (milliseconds since UNIX epoch) of when the current position was obtained",
-          "type": "number"
+          "description": "Timestamp (ISO date string) of when the current position was obtained",
+          "type": "string",
+          "format": "date-time"
         },
         "mocked": {
           "description": "`true` if the position was mocked",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -19,11 +19,16 @@ import {
   convertCoreOwnership,
   convertIcon,
   convertTranslation,
+  convertTrack,
 } from './lib/decode-conversions.js'
 // @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants.js'
-import { ExhaustivenessError, VersionIdObject, getProtoTypeName } from './lib/utils.js'
+import {
+  ExhaustivenessError,
+  VersionIdObject,
+  getProtoTypeName,
+} from './lib/utils.js'
 
 /** Map of dataTypeIds to schema names for quick lookups */
 const dataTypeIdToSchemaName: Record<string, SchemaName> = {}
@@ -74,6 +79,8 @@ export function decode(
       return convertIcon(message, versionObj)
     case 'translation':
       return convertTranslation(message, versionObj)
+    case 'track':
+      return convertTrack(message, versionObj)
     default:
       throw new ExhaustivenessError(message)
   }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -19,6 +19,7 @@ import {
   convertCoreOwnership,
   convertIcon,
   convertTranslation,
+  convertTrack,
 } from './lib/encode-conversions.js'
 import { CoreOwnership } from './index.js'
 import { ExhaustivenessError } from './lib/utils.js'
@@ -82,6 +83,11 @@ export function encode(
     }
     case 'translation': {
       const message = convertTranslation(mapeoDoc)
+      protobuf = Encode[mapeoDoc.schemaName](message).finish()
+      break
+    }
+    case 'track': {
+      const message = convertTrack(mapeoDoc)
       protobuf = Encode[mapeoDoc.schemaName](message).finish()
       break
     }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -380,9 +380,6 @@ function convertTrackPosition(
   if (!position.coords) {
     throw new Error('Missing required property `coords`')
   }
-  if (!position.timestamp) {
-    throw new Error('Missing required property `timestamp`')
-  }
   return {
     ...position,
     coords: position.coords,

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ type SupportedSchemaNames =
   | 'deviceInfo'
   | 'coreOwnership'
   | 'translation'
+  | 'track'
 
 export type SchemaName = Extract<keyof typeof dataTypeIds, SupportedSchemaNames>
 export type SchemaNameAll = keyof typeof dataTypeIds

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -265,4 +265,57 @@ export const goodDocsCompleted = [
     },
     expected: {},
   },
+  {
+    doc: {
+      docId: cachedValues.docId,
+      versionId: cachedValues.versionId,
+      schemaName: 'track',
+      createdAt: cachedValues.createdAt,
+      updatedAt: cachedValues.updatedAt,
+      createdBy: cachedValues.createdBy,
+      links: [],
+      deleted: false,
+      locations: [
+        {
+          timestamp: cachedValues.metadata.position.timestamp,
+          mocked: false,
+          coords: { latitude: 12, longitude: 34 },
+        },
+        {
+          timestamp: cachedValues.metadata.position.timestamp,
+          mocked: true,
+          coords: {
+            latitude: 12,
+            longitude: 34,
+            altitude: 123,
+            heading: 123,
+            speed: 0.123,
+            accuracy: 123,
+          },
+        },
+      ],
+      refs: [
+        {
+          id: randomBytes(32).toString('hex'),
+          type: 'observation',
+        },
+        {
+          id: randomBytes(32).toString('hex'),
+          type: 'observation',
+        },
+      ],
+      attachments: [
+        {
+          name: 'myFile',
+          type: 'photo',
+          driveDiscoveryId: cachedValues.attachments.driveDiscoveryId,
+          hash: cachedValues.attachments.hash,
+        },
+      ],
+      tags: {
+        someKeyForArrVal: ['arr', 'of', 'strings'],
+      },
+    },
+    expected: {},
+  },
 ]

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -174,4 +174,21 @@ export const goodDocsMinimal = [
     },
     expected: {},
   },
+  {
+    doc: {
+      docId: cachedValues.docId,
+      versionId: cachedValues.versionId,
+      schemaName: 'track',
+      createdAt: cachedValues.createdAt,
+      updatedAt: cachedValues.updatedAt,
+      createdBy: cachedValues.createdBy,
+      links: [],
+      deleted: false,
+      locations: [],
+      refs: [],
+      attachments: [],
+      tags: {},
+    },
+    expected: {},
+  },
 ]


### PR DESCRIPTION
Add a new `track` schema type.

This was more work than I would have hoped because I wanted to keep timestamps as integers for track locations (as opposed to converting them to ISO date strings), which required lots of backwards compat work. This was maybe a bad idea. But maybe we should switch to timestamps instead of date strings throughout, or switch to `Date` (which would require custom revivers for serializing as JSON over IPC).

Currently this is storing all data captured during track recording, apart from `altitude accuracy`, which seems unnecssary.

To display a track we only really need the latitude and longitude of each position along a track, but at the very least the timestamp is useful too, and the speed, altitude, accuracy and heading could be useful in the future. Each value adds approx 4 bytes to the stored data (64 bits). According to the SWM team tracks capture about 333 points per 1,000 meters, which, if users are going to walk an average of 10km on a track, means an overhead of 333 * 10 * 4 = ~13KB storage cost for each track per value stored.

Note: at some time soon (before adding another schema type?) it would be good to write more generic encode and decode functions, based on annotations of the protobufs maybe.

TODO:

- [x] Add tests for track encoding and decoding.