### PR TITLE
feat: add "self hosted server" device type

### DIFF
--- a/proto/deviceInfo/v1.proto
+++ b/proto/deviceInfo/v1.proto
@@ -18,6 +18,7 @@ message DeviceInfo_1 {
     mobile = 1;
     tablet = 2;
     desktop = 3;
+    selfHostedServer = 4;
   }
 
   string name = 5;

--- a/schema/deviceInfo/v1.json
+++ b/schema/deviceInfo/v1.json
@@ -19,6 +19,7 @@
         "mobile",
         "tablet",
         "desktop",
+        "selfHostedServer",
         "UNRECOGNIZED"
       ],
       "description": "Type of device"


### PR DESCRIPTION
This adds a new device type, `selfHostedServer`. This is part of our self-hosted cloud work.

Closes #187.