### PR TITLE
chore!: remove `refs` property from schemas

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -17,11 +17,6 @@ message Observation_1 {
   optional double lat = 5;
   optional double lon = 6;
 
-  message Ref {
-    bytes id = 1;
-  }
-  repeated Ref refs = 7;
-
   // ATTACHMENT
   enum AttachmentType {
     photo = 0;
@@ -34,10 +29,10 @@ message Observation_1 {
     AttachmentType type = 3;
     bytes hash = 4;
   }
-  repeated Attachment attachments = 8;
+  repeated Attachment attachments = 7;
 
   // TAGS
-  map<string, TagValue_1> tags = 9;
+  map<string, TagValue_1> tags = 8;
 
   // METADATA
   message Metadata {
@@ -69,5 +64,5 @@ message Observation_1 {
     optional Position lastSavedPosition = 4;
     optional PositionProvider positionProvider = 5;
   }
-  optional Metadata metadata = 10;
+  optional Metadata metadata = 9;
 }

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -65,20 +65,6 @@
       "minimum": -180,
       "maximum": 180
     },
-    "refs": {
-      "type": "array",
-      "description": "References to any nodes or ways that this observation is related to.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "description": "hex-encoded id of the element that this observation references",
-            "type": "string"
-          }
-        },
-        "required": ["id"]
-      }
-    },
     "attachments": {
       "type": "array",
       "description": "media or other data that are attached to this observation",
@@ -190,6 +176,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["schemaName", "tags", "refs", "attachments", "metadata"],
+  "required": ["schemaName", "tags", "attachments", "metadata"],
   "additionalProperties": false
 }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -63,7 +63,6 @@ export const convertObservation: ConvertFunction<'observation'> = (
   const obs: Observation = {
     ...jsonSchemaCommon,
     ...rest,
-    refs: message.refs?.map(({ id }) => ({ id: id.toString('hex') })),
     attachments: message.attachments.map(convertAttachment),
     tags: convertTags(message.tags),
     metadata: message.metadata || {},

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -89,9 +89,6 @@ export const convertPreset: ConvertFunction<'preset'> = (mapeoDoc) => {
 export const convertObservation: ConvertFunction<'observation'> = (
   mapeoDoc
 ) => {
-  const refs = mapeoDoc.refs.map((ref) => {
-    return { id: Buffer.from(ref.id, 'hex') }
-  })
   const attachments = mapeoDoc.attachments.map(convertAttachment)
   const metadata: Observation_1_Metadata = mapeoDoc.metadata && {
     ...Observation_1_Metadata.fromPartial(mapeoDoc.metadata),
@@ -100,7 +97,6 @@ export const convertObservation: ConvertFunction<'observation'> = (
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
-    refs,
     attachments,
     tags: convertTags(mapeoDoc.tags),
     metadata,

--- a/test/fixtures/bad-docs.js
+++ b/test/fixtures/bad-docs.js
@@ -18,7 +18,6 @@ export const badDocs = [
       updatedAt: cachedValues.updatedAt,
       createdBy: cachedValues.createdBy,
       links: [],
-      refs: [],
       attachments: [],
       tags: {},
       metadata: {},

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -21,7 +21,6 @@ export const goodDocsCompleted = [
       links: [],
       lat: 24.0424,
       lon: 21.0214,
-      refs: [],
       attachments: [
         {
           name: 'myFile',

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -21,7 +21,6 @@ export const goodDocsMinimal = [
       updatedAt: cachedValues.updatedAt,
       createdBy: cachedValues.createdBy,
       links: [],
-      refs: [],
       attachments: [],
       tags: {},
       metadata: {},


### PR DESCRIPTION
This isn't necessary for now, so we can remove it.

`refs` is still present for `Track`s.

Tested this with automated tests and by integrating it into `@mapeo/core` with a temporary build of this module.

Closes #193.