### PR TITLE
feat: add `configMetadata` to `projectSettings`

### DIFF
--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -20,9 +20,13 @@ message ProjectSettings_1 {
     repeated bytes relation = 5;
   };
 
-  optional DefaultPresets defaultPresets = 2;
+  message ConfigMetadata {
+    optional string name = 1;
+    optional google.protobuf.Timestamp buildDate = 2;
+    optional int32 fileVersion = 3;
+  }
 
-  optional string name = 5;
-  string configName = 6;
-  string configVersion = 7;
+  optional DefaultPresets defaultPresets = 2;
+  optional ConfigMetadata configMetadata = 3;
+  optional string name = 4;
 }

--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -24,7 +24,7 @@ message ProjectSettings_1 {
     string name = 1;
     google.protobuf.Timestamp buildDate = 2;
     google.protobuf.Timestamp importDate = 3;
-    uint32 fileVersion = 4;
+    string fileVersion = 4;
   }
 
   optional DefaultPresets defaultPresets = 2;

--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -23,7 +23,8 @@ message ProjectSettings_1 {
   message ConfigMetadata {
     optional string name = 1;
     optional google.protobuf.Timestamp buildDate = 2;
-    optional int32 fileVersion = 3;
+    optional google.protobuf.Timestamp importDate = 3;
+    optional int32 fileVersion = 4;
   }
 
   optional DefaultPresets defaultPresets = 2;

--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -21,10 +21,10 @@ message ProjectSettings_1 {
   };
 
   message ConfigMetadata {
-    optional string name = 1;
-    optional google.protobuf.Timestamp buildDate = 2;
-    optional google.protobuf.Timestamp importDate = 3;
-    optional int32 fileVersion = 4;
+    string name = 1;
+    google.protobuf.Timestamp buildDate = 2;
+    google.protobuf.Timestamp importDate = 3;
+    uint32 fileVersion = 4;
   }
 
   optional DefaultPresets defaultPresets = 2;

--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -23,4 +23,6 @@ message ProjectSettings_1 {
   optional DefaultPresets defaultPresets = 2;
 
   optional string name = 5;
+  string configName = 6;
+  string configVersion = 7;
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -24,8 +24,16 @@
       },
       "required": ["point", "area", "vertex", "line", "relation"],
       "additionalProperties": false
+    },
+    "configName": {
+      "description": "name of the config of the project",
+      "type": "string"
+    },
+    "configVersion": {
+      "description": "version of the config of the project",
+      "type": "string"
     }
   },
-  "required": ["schemaName"],
+  "required": ["schemaName", "configName", "configVersion"],
   "additionalProperties": false
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -43,9 +43,9 @@
           "description": "RFC3339-formatted datetime of when the configuration was imported to the project"
         },
         "fileVersion": {
-          "type": "number",
-          "minimum": 0,
-          "description": "version of the configuration file format"
+          "type": "string",
+          "description": "version of the configuration file format as comver (MAYOR.MINOR)",
+          "pattern": "^(d+).(d+)$"
         }
       },
       "additionalProperties": false,

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -48,9 +48,10 @@
           "description": "version of the configuration file format"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": ["name", "buildDate", "importDate", "fileVersion"]
     }
   },
-  "required": ["schemaName", "configMetadata"],
+  "required": ["schemaName"],
   "additionalProperties": false
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -25,15 +25,27 @@
       "required": ["point", "area", "vertex", "line", "relation"],
       "additionalProperties": false
     },
-    "configName": {
-      "description": "name of the config of the project",
-      "type": "string"
-    },
-    "configVersion": {
-      "description": "version of the config of the project",
-      "type": "string"
+    "configMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the configuration"
+        },
+        "buildDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339-formatted datetime of when the configuration was built"
+        },
+        "fileVersion": {
+          "type": "number",
+          "minimum": 0,
+          "description": "version of the configuration file format"
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "required": ["schemaName", "configName", "configVersion"],
+  "required": ["schemaName", "configMetadata"],
   "additionalProperties": false
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -37,6 +37,11 @@
           "format": "date-time",
           "description": "RFC3339-formatted datetime of when the configuration was built"
         },
+        "importDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC3339-formatted datetime of when the configuration was imported to the project"
+        },
         "fileVersion": {
           "type": "number",
           "minimum": 0,

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -44,7 +44,7 @@
         },
         "fileVersion": {
           "type": "string",
-          "description": "version of the configuration file format as comver (MAYOR.MINOR)"
+          "description": "version of the configuration file format as comver (MAJOR.MINOR)"
         }
       },
       "additionalProperties": false,

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -44,8 +44,7 @@
         },
         "fileVersion": {
           "type": "string",
-          "description": "version of the configuration file format as comver (MAYOR.MINOR)",
-          "pattern": "^(d+).(d+)$"
+          "description": "version of the configuration file format as comver (MAYOR.MINOR)"
         }
       },
       "additionalProperties": false,

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -24,6 +24,8 @@ import { ExhaustivenessError, VersionIdObject, getVersionId } from './utils.js'
 import type { Observation, Track } from '../index.js'
 import type { Observation_1_Attachment } from '../proto/observation/v1.js'
 import type { Track_1_Position } from '../proto/track/v1.js'
+import { ProjectSettings_1_ConfigMetadata } from '../proto/projectSettings/v1.js'
+import { ProjectSettings } from '../schema/projectSettings.js'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
@@ -38,6 +40,7 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
 ) => {
   const { common, schemaVersion, defaultPresets, ...rest } = message
   const jsonSchemaCommon = convertCommon(common, versionObj)
+  const configMetadata = convertConfigMetadata(message.configMetadata)
   return {
     ...jsonSchemaCommon,
     ...rest,
@@ -50,8 +53,23 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
           relation: defaultPresets.relation.map((r) => r.toString('hex')),
         }
       : undefined,
-    configMetadata: message.configMetadata || {},
+    configMetadata,
   }
+}
+
+function convertConfigMetadata(
+  configMetadata: ProjectSettings_1_ConfigMetadata | undefined
+): ProjectSettings['configMetadata'] {
+  if (!configMetadata) {
+    throw new Error('Missing required property configMetadata')
+  }
+  if (!configMetadata.importDate) {
+    throw new Error('Missing required property configMetadata.importDate')
+  }
+  if (!configMetadata.buildDate) {
+    throw new Error('Missing required property configMetadata.buildDate')
+  }
+  return configMetadata as ProjectSettings['configMetadata']
 }
 
 export const convertObservation: ConvertFunction<'observation'> = (

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -50,6 +50,7 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
           relation: defaultPresets.relation.map((r) => r.toString('hex')),
         }
       : undefined,
+    configMetadata: message.configMetadata || {},
   }
 }
 

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -40,7 +40,10 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
 ) => {
   const { common, schemaVersion, defaultPresets, ...rest } = message
   const jsonSchemaCommon = convertCommon(common, versionObj)
-  const configMetadata = convertConfigMetadata(message.configMetadata)
+  let configMetadata
+  if (rest.configMetadata) {
+    configMetadata = convertConfigMetadata(rest.configMetadata)
+  }
   return {
     ...jsonSchemaCommon,
     ...rest,
@@ -58,15 +61,12 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
 }
 
 function convertConfigMetadata(
-  configMetadata: ProjectSettings_1_ConfigMetadata | undefined
+  configMetadata: ProjectSettings_1_ConfigMetadata
 ): ProjectSettings['configMetadata'] {
-  if (!configMetadata) {
-    throw new Error('Missing required property configMetadata')
-  }
-  if (!configMetadata.importDate) {
+  if (!configMetadata?.importDate) {
     throw new Error('Missing required property configMetadata.importDate')
   }
-  if (!configMetadata.buildDate) {
+  if (!configMetadata?.buildDate) {
     throw new Error('Missing required property configMetadata.buildDate')
   }
   return configMetadata as ProjectSettings['configMetadata']

--- a/test/fixtures/cached.js
+++ b/test/fixtures/cached.js
@@ -30,4 +30,8 @@ export const cachedValues = {
   fieldIds: [randomBytes(32).toString('hex')],
   iconId: randomBytes(32).toString('hex'),
   docIdRef: randomBytes(32).toString('hex'),
+  configMetadata: {
+    buildDate: date,
+    importDate: date,
+  },
 }

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -90,6 +90,7 @@ export const goodDocsCompleted = [
       name: 'myProject',
       configMetadata: {
         name: 'mapeo-config-1',
+        fileVersion: '1.0',
         buildDate: cachedValues.configMetadata.buildDate,
         importDate: cachedValues.configMetadata.importDate,
       },

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -88,8 +88,11 @@ export const goodDocsCompleted = [
         relation: cachedValues.defaultPresets.point,
       },
       name: 'myProject',
-      configName: 'mapeo-config',
-      configVersion: '1.0.0',
+      configMetadata: {
+        name: 'mapeo-config-1',
+        buildDate: cachedValues.configMetadata.buildDate,
+        importDate: cachedValues.configMetadata.importDate,
+      },
       deleted: false,
     },
     expected: {},

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -88,6 +88,8 @@ export const goodDocsCompleted = [
         relation: cachedValues.defaultPresets.point,
       },
       name: 'myProject',
+      configName: 'mapeo-config',
+      configVersion: '1.0.0',
       deleted: false,
     },
     expected: {},

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -37,6 +37,8 @@ export const goodDocsMinimal = [
       createdAt: cachedValues.createdAt,
       updatedAt: cachedValues.updatedAt,
       createdBy: cachedValues.createdBy,
+      configName: 'mapeo-config',
+      configVersion: '1.0.0',
       links: [],
       deleted: false,
     },

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -37,8 +37,11 @@ export const goodDocsMinimal = [
       createdAt: cachedValues.createdAt,
       updatedAt: cachedValues.updatedAt,
       createdBy: cachedValues.createdBy,
-      configName: 'mapeo-config',
-      configVersion: '1.0.0',
+      configMetadata: {
+        name: 'mapeo-config',
+        buildDate: cachedValues.configMetadata.buildDate,
+        importDate: cachedValues.configMetadata.importDate,
+      },
       links: [],
       deleted: false,
     },

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -39,6 +39,7 @@ export const goodDocsMinimal = [
       createdBy: cachedValues.createdBy,
       configMetadata: {
         name: 'mapeo-config',
+        fileVersion: '1.0',
         buildDate: cachedValues.configMetadata.buildDate,
         importDate: cachedValues.configMetadata.importDate,
       },


### PR DESCRIPTION
This should move forward exposing config metadata to the frontend. 
Part of https://github.com/digidem/comapeo-mobile/issues/527