### PR TITLE
add unspecified field to enums

### DIFF
--- a/proto/deviceInfo/v1.proto
+++ b/proto/deviceInfo/v1.proto
@@ -14,9 +14,10 @@ message DeviceInfo_1 {
   Common_1 common = 1;
 
   enum DeviceType {
-    mobile = 0;
-    tablet = 1;
-    desktop = 2;
+    device_type_unspecified = 0;
+    mobile = 1;
+    tablet = 2;
+    desktop = 3;
   }
 
   string name = 5;

--- a/proto/field/v1.proto
+++ b/proto/field/v1.proto
@@ -16,16 +16,18 @@ message Field_1 {
 
   optional string tagKey = 5 [(required) = true];
   enum Type {
-    text = 0;
-    number = 1;
-    selectOne = 2;
-    selectMultiple = 3;
+    type_unspecified = 0;
+    text = 1;
+    number = 2;
+    selectOne = 3;
+    selectMultiple = 4;
   }
   Type type = 6 [(required) = true];
   optional string label = 7 [(required) = true];
   enum Appearance {
-    multiline = 0;
-    singleline = 1;
+    appearance_unspecified = 0;
+    multiline = 1;
+    singleline = 2;
   }
   optional Appearance appearance = 8;
   optional bool snakeCase = 9;

--- a/proto/icon/v1.proto
+++ b/proto/icon/v1.proto
@@ -16,9 +16,10 @@ message Icon_1 {
 
   message IconVariantPng {
     enum PixelDensity {
-      x1 = 0;
-      x2 = 1;
-      x3 = 2;
+      pixel_density_unspecified = 0;
+      x1 = 1;
+      x2 = 2;
+      x3 = 3;
     }
 
     PixelDensity pixelDensity = 1 [(required) = true];
@@ -32,9 +33,10 @@ message Icon_1 {
     }
 
     enum Size {
-      small = 0;
-      medium = 1;
-      large = 2;
+      size_unspecified = 0;
+      small = 1;
+      medium = 2;
+      large = 3;
     }
 
     message BlobVersionId {

--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -24,9 +24,10 @@ message Observation_1 {
 
   // ATTACHMENT
   enum AttachmentType {
-    photo = 0;
-    video = 1;
-    audio = 2;
+    attachment_type_unspecified = 0;
+    photo = 1;
+    video = 2;
+    audio = 3;
   }
   message Attachment {
     bytes driveDiscoveryId = 1;

--- a/proto/preset/v1.proto
+++ b/proto/preset/v1.proto
@@ -16,11 +16,12 @@ message Preset_1 {
 
   string name = 5;
   enum Geometry {
-    point = 0;
-    vertex = 1;
-    line = 2;
-    area = 3;
-    relation = 4;
+    geometry_unspecified = 0;
+    point = 1;
+    vertex = 2;
+    line = 3;
+    area = 4;
+    relation = 5;
   }
   repeated Geometry geometry = 6;
   map<string, TagValue_1> tags = 7;

--- a/proto/track/v1.proto
+++ b/proto/track/v1.proto
@@ -19,7 +19,8 @@ message Track_1 {
   map<string, TagValue_1> tags = 5;
 
   enum RefType {
-    observation = 0;
+    ref_type_unspecified = 0;
+    observation = 1;
   }
   message Ref {
     bytes id = 1;
@@ -27,9 +28,10 @@ message Track_1 {
   }
 
   enum AttachmentType {
-    photo = 0;
-    video = 1;
-    audio = 2;
+    attachment_type_unspecified = 0;
+    photo = 1;
+    video = 2;
+    audio = 3;
   }
   message Attachment {
     bytes driveDiscoveryId = 1;

--- a/schema/deviceInfo/v1.json
+++ b/schema/deviceInfo/v1.json
@@ -14,7 +14,13 @@
     },
     "deviceType": {
       "type": "string",
-      "enum": ["mobile", "tablet", "desktop", "UNRECOGNIZED"],
+      "enum": [
+        "device_type_unspecified",
+        "mobile",
+        "tablet",
+        "desktop",
+        "UNRECOGNIZED"
+      ],
       "description": "Type of device"
     }
   },

--- a/schema/field/v1.json
+++ b/schema/field/v1.json
@@ -18,12 +18,20 @@
       "description": "Type of field - defines how the field is displayed to the user.",
       "type": "string",
       "meta:enum": {
+        "type_unspecified": "for backwards compatibility, unspecified type of appearance",
         "text": "Freeform text field",
         "number": "Allows only numbers",
         "selectOne": "Select one item from a list of pre-defined options",
         "selectMultiple": "Select any number of items from a list of pre-defined options"
       },
-      "enum": ["text", "number", "selectOne", "selectMultiple", "UNRECOGNIZED"]
+      "enum": [
+        "type_unspecified",
+        "text",
+        "number",
+        "selectOne",
+        "selectMultiple",
+        "UNRECOGNIZED"
+      ]
     },
     "label": {
       "description": "Default language label for the form field label",
@@ -33,10 +41,17 @@
       "description": "For text fields, display as a single-line or multi-line field",
       "type": "string",
       "meta:enum": {
+        "appearance_unspecified": "for backwards compatibility, unspecified type of appearance",
         "singleline": "Text will be cut-off if more than one line",
         "multiline": "Text will wrap to multiple lines within text field"
       },
-      "enum": ["singleline", "multiline"],
+      "enum": [
+        "appearance_unspecified",
+        "singleline",
+        "multiline",
+        "UNRECOGNIZED"
+      ],
+
       "default": "multiline"
     },
     "snakeCase": {

--- a/schema/icon/v1.json
+++ b/schema/icon/v1.json
@@ -7,7 +7,7 @@
   "definitions": {
     "size": {
       "type": "string",
-      "enum": ["small", "medium", "large"]
+      "enum": ["size_unspecified", "small", "medium", "large"]
     },
     "blobVersionId": {
       "description": "Version id of the icon blob. Each id is id (hex-encoded 32 byte buffer) and index number, separated by '/'",

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -99,7 +99,13 @@
             "meta:enum": {
               "UNRECOGNIZED": "future attachment type"
             },
-            "enum": ["photo", "video", "audio", "UNRECOGNIZED"]
+            "enum": [
+              "attachment_type_unspecified",
+              "photo",
+              "video",
+              "audio",
+              "UNRECOGNIZED"
+            ]
           },
           "hash": {
             "type": "string",

--- a/schema/track/v1.json
+++ b/schema/track/v1.json
@@ -74,7 +74,7 @@
           "type": {
             "description": "type of the element that this track references",
             "type": "string",
-            "enum": ["observation", "UNRECOGNIZED"],
+            "enum": ["ref_type_unspecified", "observation", "UNRECOGNIZED"],
             "meta:enum": {
               "UNRECOGNIZED": "future reference type"
             }
@@ -103,7 +103,13 @@
             "meta:enum": {
               "UNRECOGNIZED": "future attachment type"
             },
-            "enum": ["photo", "video", "audio", "UNRECOGNIZED"]
+            "enum": [
+              "attachment_type_unspecified",
+              "photo",
+              "video",
+              "audio",
+              "UNRECOGNIZED"
+            ]
           },
           "hash": {
             "type": "string",

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -85,8 +85,6 @@ export const convertField: ConvertFunction<'field'> = (message, versionObj) => {
       ...rest,
       tagKey: message.tagKey,
       label: message.label || message.tagKey,
-      appearance:
-        message.appearance === 'UNRECOGNIZED' ? undefined : message.appearance,
       options:
         message.options.length > 0
           ? message.options.reduce<Exclude<FieldOptions, undefined>>(


### PR DESCRIPTION
should close #171. 
Instead of having a field "unspecified" for enums, I had to be deliberate (so `${enum_name_in_snake_case}_unspecified`) since protobufs don't allow enums to have fields with the same name