### PR TITLE
chore: add iconRef to preset schema

### DIFF
--- a/schema/preset/v1.json
+++ b/schema/preset/v1.json
@@ -94,6 +94,21 @@
         "required": ["docId", "versionId"]
       }
     },
+    "iconRef": {
+      "type": "object",
+      "description": "References to the icon that this preset is related to.",
+      "properties": {
+        "docId": {
+          "description": "hex-encoded id of the element that this observation references",
+          "type": "string"
+        },
+        "versionId": {
+          "description": "core discovery id (hex-encoded 32-byte buffer) and core index number, separated by '/'",
+          "type": "string"
+        }
+      },
+      "required": ["docId", "versionId"]
+    },
     "terms": {
       "description": "Synonyms or related terms (used for search)",
       "type": "array",

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -137,6 +137,16 @@ export const convertPreset: ConvertFunction<'preset'> = (
       geomType !== 'UNRECOGNIZED'
   )
 
+  let iconRef
+  if (rest.iconRef) {
+    // iconRef is not required property on the schema, but if it does exist, then a versionId must be present
+    if (!rest.iconRef.versionId)
+      throw new Error('found iconRef on preset but is missing versionId')
+    iconRef = {
+      docId: rest.iconRef.docId.toString('hex'),
+      versionId: getVersionId(rest.iconRef.versionId),
+    }
+  }
   return {
     ...jsonSchemaCommon,
     ...rest,
@@ -151,6 +161,7 @@ export const convertPreset: ConvertFunction<'preset'> = (
         versionId: getVersionId(versionId),
       }
     }),
+    iconRef,
   }
 }
 

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -75,6 +75,15 @@ export const convertPreset: ConvertFunction<'preset'> = (mapeoDoc) => {
   if (!mapeoDoc.color.match(colorRegex)) {
     throw new Error(`invalid color string ${mapeoDoc.color}`)
   }
+
+  let iconRef
+  if (mapeoDoc.iconRef) {
+    iconRef = {
+      docId: Buffer.from(mapeoDoc.iconRef.docId, 'hex'),
+      versionId: parseVersionId(mapeoDoc.iconRef.versionId),
+    }
+  }
+
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
@@ -85,6 +94,7 @@ export const convertPreset: ConvertFunction<'preset'> = (mapeoDoc) => {
       docId: Buffer.from(docId, 'hex'),
       versionId: parseVersionId(versionId),
     })),
+    iconRef,
   }
 }
 


### PR DESCRIPTION
On https://github.com/digidem/mapeo-schema/pull/199/ we forgot to add `iconRef` to the `Preset` JSONSchema. This wasn't caught since `iconRef` is optional on the protobuf definition. Despite that I thought it would be caught since we don't allow additional properties on any JSONSchema. 