### PR TITLE
chore: check code formatting on test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build:tsc": "tsc",
     "build:copy": "cpy 'intermediate/generated/**' 'intermediate/src/**' dist/",
     "build:doc": "typedoc src/index.ts --tsconfig tsconfig.typedoc.json --plugin typedoc-plugin-markdown",
+    "lint": "prettier --check .",
     "prepack": "npm run build",
+    "pretest": "npm run lint",
     "test": "node --test test"
   },
   "repository": {


### PR DESCRIPTION
`npm test` now runs `prettier --check .` to ensure all of our files are formatted correctly.