### PR TITLE
chore: move type out of `docRef` and call it `docRefType`

### DIFF
--- a/proto/translation/v1.proto
+++ b/proto/translation/v1.proto
@@ -21,7 +21,7 @@ message Translation_1 {
   message DocRef {
     bytes docId = 1;
     VersionId_1 versionId = 2;
-    string type = 3;
   }
+  string refType = 7;
 
 }

--- a/proto/translation/v1.proto
+++ b/proto/translation/v1.proto
@@ -22,6 +22,16 @@ message Translation_1 {
     bytes docId = 1;
     VersionId_1 versionId = 2;
   }
-  string refType = 7;
+  enum DocRefType {
+    type_unspecified = 0;
+    deviceInfo = 1;
+    preset = 2;
+    field = 3;
+    observation = 4;
+    projectSettings = 5;
+    role = 6;
+    track = 7;
+  }
+  DocRefType docRefType = 7;
 
 }

--- a/schema/translation/v1.json
+++ b/schema/translation/v1.json
@@ -19,13 +19,13 @@
         "versionId": {
           "description": "core discovery id (hex-encoded 32-byte buffer) and core index number, separated by '/'",
           "type": "string"
-        },
-        "type": {
-          "description": "type of the element that this translation references",
-          "type": "string"
         }
       },
-      "required": ["docId", "versionId", "type"]
+      "required": ["docId", "versionId"]
+    },
+    "refType": {
+      "description": "type of the element that this translation references",
+      "type": "string"
     },
     "propertyRef": {
       "type": "string",
@@ -47,6 +47,7 @@
   "required": [
     "schemaName",
     "docRef",
+    "refType",
     "propertyRef",
     "languageCode",
     "regionCode",

--- a/schema/translation/v1.json
+++ b/schema/translation/v1.json
@@ -23,9 +23,20 @@
       },
       "required": ["docId", "versionId"]
     },
-    "refType": {
+    "docRefType": {
       "description": "type of the element that this translation references",
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "type_unspecified",
+        "deviceInfo",
+        "preset",
+        "field",
+        "observation",
+        "projectSettings",
+        "role",
+        "track",
+        "UNRECOGNIZED"
+      ]
     },
     "propertyRef": {
       "type": "string",
@@ -47,7 +58,7 @@
   "required": [
     "schemaName",
     "docRef",
-    "refType",
+    "docRefType",
     "propertyRef",
     "languageCode",
     "regionCode",

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -245,7 +245,6 @@ export const convertTranslation: ConvertFunction<'translation'> = (
     docRef: {
       docId: message.docRef.docId.toString('hex'),
       versionId: getVersionId(message.docRef.versionId),
-      type: message.docRef.type,
     },
   }
 }

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -207,7 +207,6 @@ export const convertTranslation: ConvertFunction<'translation'> = (
     docRef: {
       docId: Buffer.from(mapeoDoc.docRef.docId, 'hex'),
       versionId: parseVersionId(mapeoDoc.docRef.versionId),
-      type: mapeoDoc.docRef.type,
     },
   }
 }

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -270,7 +270,7 @@ export const goodDocsCompleted = [
         docId: cachedValues.refs.docId,
         versionId: cachedValues.refs.versionId,
       },
-      refType: 'preset',
+      docRefType: 'preset',
       propertyRef: 'terms[0]',
       languageCode: 'es',
       regionCode: 'AR',

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -269,8 +269,8 @@ export const goodDocsCompleted = [
       docRef: {
         docId: cachedValues.refs.docId,
         versionId: cachedValues.refs.versionId,
-        type: 'preset',
       },
+      refType: 'preset',
       propertyRef: 'terms[0]',
       languageCode: 'es',
       regionCode: 'AR',

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -174,8 +174,8 @@ export const goodDocsMinimal = [
       docRef: {
         docId: cachedValues.refs.docId,
         versionId: cachedValues.refs.versionId,
-        type: 'field',
       },
+      refType: 'field',
       propertyRef: 'label',
       languageCode: 'qu',
       regionCode: 'PE',

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -175,7 +175,7 @@ export const goodDocsMinimal = [
         docId: cachedValues.refs.docId,
         versionId: cachedValues.refs.versionId,
       },
-      refType: 'field',
+      docRefType: 'field',
       propertyRef: 'label',
       languageCode: 'qu',
       regionCode: 'PE',


### PR DESCRIPTION
when adding `docRef` to translation I initially put the `type` of ref inside `docRef`. Integrating with mapeo-core-next I realized that some stuff were more complicated than needed and that the code (and types) could be simpler if we removed `type` from `docRef` and added as its own feld (now called `refType`)

