### PR TITLE
feat: decode future schema versions without throwing

### DIFF
--- a/scripts/lib/generate-config.js
+++ b/scripts/lib/generate-config.js
@@ -1,11 +1,7 @@
 /**
  * @param {ReturnType<import('./parse-config').parseConfig>} config
  */
-export function generateConfig({
-  currentSchemaVersions,
-  dataTypeIds,
-  protoTypeDefs,
-}) {
+export function generateConfig({ currentSchemaVersions, dataTypeIds }) {
   const idsLines = ['export const dataTypeIds = {']
   for (const [schemaName, dataTypeId] of Object.entries(dataTypeIds)) {
     idsLines.push(`  ${schemaName}: '${dataTypeId}',`)
@@ -20,26 +16,5 @@ export function generateConfig({
   }
   versionsLines.push('} as const')
 
-  const knownVersions = {}
-  for (const { schemaName, schemaVersion } of protoTypeDefs) {
-    const existing = knownVersions[schemaName]
-    knownVersions[schemaName] = existing
-      ? [...existing, schemaVersion]
-      : [schemaVersion]
-  }
-
-  const knownVersionsLines = ['export const knownSchemaVersions = {']
-  for (const [schemaName, schemaVersions] of Object.entries(knownVersions)) {
-    knownVersionsLines.push(`  ${schemaName}: [${schemaVersions.join(', ')}],`)
-  }
-  knownVersionsLines.push('}')
-
-  return [
-    ...idsLines,
-    '',
-    ...versionsLines,
-    '',
-    ...knownVersionsLines,
-    '',
-  ].join('\n')
+  return [...idsLines, '', ...versionsLines].join('\n')
 }

--- a/scripts/lib/generate-proto-types.js
+++ b/scripts/lib/generate-proto-types.js
@@ -20,11 +20,11 @@ export function generateProtoTypes({ currentSchemaVersions, protoTypeDefs }) {
       .join('\n  | ')
 
   const protoTypesWithSchemaInfo =
-    '/** Union of all Proto Types (including non-current versions) with schemaName and schemaVersion */\n' +
+    '/** Union of all Proto Types with schemaName and schemaVersion */\n' +
     'export type ProtoTypesWithSchemaInfo =\n  | ' +
     protoTypeDefs
-      .map(({ schemaName, schemaVersion, typeName }) => {
-        return `(${typeName} & { schemaName: '${schemaName}', schemaVersion: ${schemaVersion} })`
+      .map(({ schemaName, typeName }) => {
+        return `(${typeName} & { schemaName: '${schemaName}', schemaVersion: number })`
       })
       .join('\n  | ')
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,16 @@
 import { type ProtoTypeNames } from '../proto/types.js'
 import {
-  type ValidSchemaDef,
   type MapeoDoc,
   type MapeoValue,
   type FilterBySchemaName,
 } from '../types.js'
+
+export function getOwn<T extends object, K extends keyof T>(
+  obj: T,
+  key: K
+): undefined | T[K] {
+  return Object.hasOwn(obj, key) ? obj[key] : undefined
+}
 
 export class ExhaustivenessError extends Error {
   constructor(value: never) {
@@ -14,12 +20,13 @@ export class ExhaustivenessError extends Error {
 
 /**
  * Get the name of the type, e.g. `Observation_5` for schemaName `observation`
- * and schemaVersion `1`
+ * and schemaVersion `5`
  */
-export function getProtoTypeName(schemaDef: ValidSchemaDef): ProtoTypeNames {
-  return (capitalize(schemaDef.schemaName) +
-    '_' +
-    schemaDef.schemaVersion) as ProtoTypeNames
+export function getProtoTypeName(
+  schemaName: string,
+  schemaVersion: number
+): ProtoTypeNames {
+  return (capitalize(schemaName) + '_' + schemaVersion) as ProtoTypeNames
 }
 
 function capitalize<T extends string>(str: T): Capitalize<T> {

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -1,6 +1,29 @@
 // @ts-check
+import assert from 'node:assert/strict'
 import test from 'node:test'
-import { ExhaustivenessError } from '../../dist/lib/utils.js'
+import { ExhaustivenessError, getOwn } from '../../dist/lib/utils.js'
+
+test('getOwn', () => {
+  class Foo {
+    ownProperty = 123
+    inheritedProperty() {
+      return 789
+    }
+  }
+  const foo = new Foo()
+  assert.equal(getOwn(foo, 'ownProperty'), 123)
+  assert.equal(getOwn(foo, 'inheritedProperty'), undefined)
+  assert.equal(
+    getOwn(foo, /** @type {keyof Foo} */ ('hasOwnProperty')),
+    undefined
+  )
+
+  const nullProto = Object.create(null)
+  nullProto.foo = 123
+  assert.equal(getOwn(nullProto, 'foo'), 123)
+  assert.equal(getOwn(nullProto, 'bar'), undefined)
+  assert.equal(getOwn(nullProto, 'hasOwnProperty'), undefined)
+})
 
 test('ExhaustivenessError', () => {
   // These should not throw.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2019",
-    "lib": ["es2020"],
+    "lib": ["es2022"],
     "noImplicitAny": true,
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
We can now decode future schema versions without throwing. For example, if some future version encodes `Observation_2`, we can decode it as an `Observation_1`.

Closes #168.