### PR TITLE
chore: version all schemas to v1

### DIFF
--- a/schema/field/v1.json
+++ b/schema/field/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://mapeo.world/schemas/field/v2.json",
+  "$id": "http://mapeo.world/schemas/field/v1.json",
   "title": "Field",
   "description": "A field defines a form field that will be shown to the user when creating or editing a map entity. Presets define which fields are shown to the user for a particular map entity. The field definition defines whether the field should show as a text box, multiple choice, single-select, etc. It defines what tag-value is set when the field is entered.",
   "type": "object",

--- a/schema/icon/v1.json
+++ b/schema/icon/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://mapeo.world/schemas/icon/v2.json",
+  "$id": "http://mapeo.world/schemas/icon/v1.json",
   "title": "Icon",
   "description": "An Icon represents metadata to retrieve an Icon blob",
   "type": "object",

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://mapeo.world/schemas/observation/v5.json",
+  "$id": "http://mapeo.world/schemas/observation/v1.json",
   "title": "Observation",
   "description": "An observation is something that has been observed at a particular time and place. It is a subjective statement of 'I saw/heard this, here'",
   "definitions": {

--- a/schema/preset/v1.json
+++ b/schema/preset/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://mapeo.world/schemas/preset/v2.json",
+  "$id": "http://mapeo.world/schemas/preset/v1.json",
   "title": "Preset",
   "description": "Presets define how map entities are displayed to the user. They define the icon used on the map, and the fields / questions shown to the user when they create or edit the entity on the map. The `tags` property of a preset is used to match the preset with observations, nodes, ways and relations. If multiple presets match, the one that matches the most tags is used.",
   "definitions": {


### PR DESCRIPTION
should close #202 
all version of JSONSchemas (field `$id` on the schema file), should be the same as the filename version, and they should all be version 1