### PR TITLE
chore: use npm ci on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,5 +47,5 @@ jobs:
           # optional: set this secret in your repo config for publishing to NPM
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
-            npm install
+            npm ci
             npm run build


### PR DESCRIPTION
previously we were using `npm install`