### PR TITLE
chore: update type-fest dependency to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "compact-encoding": "^2.12.0",
         "protobufjs": "^7.2.5",
-        "type-fest": "^4.1.0"
+        "type-fest": "^4.26.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.26.1",
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.1.0.tgz",
-      "integrity": "sha512-VJGJVepayd8OWavP+rgXt4i3bfLk+tSomTV7r4mca2XD/oTCWnkJlNkpXavkxdmtU2aKdAmFGeHvoQutOVHCZg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "compact-encoding": "^2.12.0",
     "protobufjs": "^7.2.5",
-    "type-fest": "^4.1.0"
+    "type-fest": "^4.26.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
This updates `type-fest` to v4.26.0, the latest version.