### PR TITLE
feat!: make observation location optional

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -15,8 +15,8 @@ message Observation_1 {
 
   Common_1 common = 1;
 
-  double lat = 5;
-  double lon = 6;
+  optional double lat = 5;
+  optional double lon = 6;
 
   // ATTACHMENT
   enum AttachmentType {

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -206,6 +206,6 @@
       "required": ["docId", "versionId"]
     }
   },
-  "required": ["schemaName", "tags", "attachments", "lat", "lon"],
+  "required": ["schemaName", "tags", "attachments"],
   "additionalProperties": false
 }


### PR DESCRIPTION
This is a partial revert of 4ce47f09ba980fbc70a978b1afc399e22313382e.

It turns out that observations can, in edge cases, lack a location. This makes its `lat` and `lon` fields optional.