### PR TITLE
fix!: make Observation metadata coords fields optional

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -47,10 +47,10 @@ message Observation_1 {
       message Coords {
         double latitude = 1;
         double longitude = 2;
-        double altitude = 3;
-        double heading = 4;
-        double speed = 5;
-        double accuracy = 6;
+        optional double altitude = 3;
+        optional double heading = 4;
+        optional double speed = 5;
+        optional double accuracy = 6;
       }
       optional Coords coords = 3;
     }

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -22,14 +22,7 @@
         "coords": {
           "description": "Position details, should be self explanatory. Units in meters",
           "type": "object",
-          "required": [
-            "latitude",
-            "longitude",
-            "altitude",
-            "heading",
-            "speed",
-            "accuracy"
-          ],
+          "required": ["latitude", "longitude"],
           "properties": {
             "latitude": {
               "type": "number"


### PR DESCRIPTION
This object should match [how we collect the data on the frontend][0].

Closes #231.

[0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobjectcoords