### PR TITLE
chore!: make Preset's `iconRef` optional

### DIFF
--- a/proto/preset/v1.proto
+++ b/proto/preset/v1.proto
@@ -21,7 +21,7 @@ message Preset_1 {
   map<string, TagValue_1> addTags = 8;
   map<string, TagValue_1> removeTags = 9;
   repeated FieldRef fieldRefs = 10;
-  IconRef iconRef = 11;
+  optional IconRef iconRef = 11;
   repeated string terms = 12;
   string color = 13;
 

--- a/schema/preset/v1.json
+++ b/schema/preset/v1.json
@@ -131,8 +131,7 @@
     "fieldRefs",
     "schemaName",
     "terms",
-    "color",
-    "iconRef"
+    "color"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
This is a partial revert of 4ce47f09ba980fbc70a978b1afc399e22313382e.

We shouldn't have made `iconRef` optional on `Preset`s. This reverts that.