### PR TITLE
chore!: make Field's `universal` property optional in schema

### DIFF
--- a/schema/field/v1.json
+++ b/schema/field/v1.json
@@ -102,6 +102,6 @@
       "type": "string"
     }
   },
-  "required": ["tagKey", "type", "label", "schemaName", "universal"],
+  "required": ["tagKey", "type", "label", "schemaName"],
   "additionalProperties": false
 }

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -64,6 +64,7 @@ export const convertField: ConvertFunction<'field'> = (mapeoDoc) => {
           }
         })
       : [],
+    universal: Boolean(mapeoDoc.universal),
   }
 }
 


### PR DESCRIPTION
This is a partial revert of 4ce47f09ba980fbc70a978b1afc399e22313382e.

`universal` should be non-optional in the protobuf (for serialization) but optional in the schema. This fixes that.