### PR TITLE
feat: add `altitudeAccuracy` to observation metadata

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -51,6 +51,7 @@ message Observation_1 {
         optional double heading = 4;
         optional double speed = 5;
         optional double accuracy = 6;
+        optional double altitudeAccuracy = 7;
       }
       optional Coords coords = 3;
     }

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -33,6 +33,9 @@
             "altitude": {
               "type": "number"
             },
+            "altitudeAccuracy": {
+              "type": "number"
+            },
             "heading": {
               "type": "number"
             },


### PR DESCRIPTION
This object matches [Expo's `LocationObjectCoords` type][0], so we should take all of its fields. We were missing `altitudeAccuracy`.

[0]: https://docs.expo.dev/versions/latest/sdk/location/#locationobjectcoords