### PR TITLE
test: use correct type for fixtures

### DIFF
--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -6,7 +6,7 @@ import { randomBytes } from 'node:crypto'
 /**
  * @type {Array<{
  *   expected: Partial<import('../../dist/types').MapeoDoc>,
- *   doc: import('../../dist/types').MapeoDocInternal
+ *   doc: import('../../dist/types').MapeoDocDecode
  * }>}
  */
 export const goodDocsCompleted = [

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -8,7 +8,7 @@ import { randomBytes } from 'node:crypto'
  *
  * @type {Array<{
  *   expected: Partial<import('../../dist/types').MapeoDoc>,
- *   doc: import('../../dist/types').MapeoDocInternal
+ *   doc: import('../../dist/types').MapeoDocDecode
  * }>}
  */
 export const goodDocsMinimal = [


### PR DESCRIPTION
1f239c9f77a8db8afba92d77bdf7c34cfa730753 replaced `MapeoDocInternal` with `MapeoDocDecode` and `MapeoDocEncode`. This updates our fixtures to use those, because it was previously (incorrectly) using `MapeoDocInternal`.

`git grep MapeoDocInternal` returns no results after this change.