### PR TITLE
fix: don't require iconRef for presets

### DIFF
--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -158,9 +158,8 @@ export const convertPreset: ConvertFunction<'preset'> = (
       docId: rest.iconRef.docId.toString('hex'),
       versionId: getVersionId(rest.iconRef.versionId),
     }
-  } else {
-    throw new Error('missing iconRef for preset')
   }
+
   return {
     ...jsonSchemaCommon,
     ...rest,


### PR DESCRIPTION
Followup for 4dc97dce071671291874e68da02702b94af3a8a1.