### PR TITLE
fix: `validate` shouldn't throw

### DIFF
--- a/scripts/lib/generate-jsonschema-exports.js
+++ b/scripts/lib/generate-jsonschema-exports.js
@@ -2,10 +2,7 @@
 import { default as _ } from '@json-schema-tools/dereferencer'
 
 // Dereferencer's exports are all wrong for ESM imports
-/** @type {any} */
-const JsonSchemaDereferencer =
-  // @ts-ignore
-  _.default
+const JsonSchemaDereferencer = /** @type {any} */ (_).default
 
 /** @typedef {import('../../src/types.js').SchemaName} SchemaName */
 /** @typedef {import('json-schema').JSONSchema7} JSONSchema */

--- a/scripts/lib/generate-jsonschema-ts.js
+++ b/scripts/lib/generate-jsonschema-ts.js
@@ -12,11 +12,18 @@ export async function generateJSONSchemaTS(config, jsonSchemas) {
   /** @type {Record<string, string>} */
   const typescriptDefs = {}
   for (const [schemaName, jsonSchema] of Object.entries(jsonSchemas.values)) {
-    // @ts-ignore
-    const ts = await compile(jsonSchema, capitalize(schemaName), {
-      additionalProperties: false,
-      unknownAny: false,
-    })
+    const ts = await compile(
+      /**
+       * This argument is a v7 JSON Schema but the function expects a v4 schema.
+       * It should be fine, so we cast it to `any`.
+       * @type {any}
+       */ (jsonSchema),
+      capitalize(schemaName),
+      {
+        additionalProperties: false,
+        unknownAny: false,
+      }
+    )
     typescriptDefs[schemaName] = ts
   }
 

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -21,7 +21,6 @@ import {
   convertTranslation,
   convertTrack,
 } from './lib/decode-conversions.js'
-// @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants.js'
 import {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -5,7 +5,6 @@ import {
   type ValidSchemaDef,
 } from './types.js'
 import { currentSchemaVersions, dataTypeIds } from './config.js'
-// @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES } from './constants.js'
 import { Encode } from './proto/index.js'

--- a/src/typedefs/compact-encoding.d.ts
+++ b/src/typedefs/compact-encoding.d.ts
@@ -1,0 +1,1 @@
+declare module 'compact-encoding'

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,6 @@
 import { MapeoValue, FilterBySchemaName, SchemaName } from './types.js'
 import * as validations from './validations.js'
+import { getOwn } from './lib/utils.js'
 import {
   type ValidateFunction as AjvValidateFunction,
   type DefinedError,
@@ -19,7 +20,15 @@ const validate: ValidateFunction = <
   schemaName: TSchemaName,
   obj: unknown
 ): obj is FilterBySchemaName<MapeoValue, TSchemaName> => {
-  const validateSchema = validations[schemaName] as AjvValidateFunction
+  validate.errors = null
+
+  const validateSchema = getOwn(validations, schemaName) as
+    | undefined
+    | AjvValidateFunction
+  if (!validateSchema) {
+    return false
+  }
+
   const result = validateSchema(obj)
   validate.errors = validateSchema.errors as DefinedError[]
   return result

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -205,8 +205,7 @@ export const goodDocsCompleted = [
       updatedAt: cachedValues.updatedAt,
       links: [],
       name: 'my device name',
-      // @ts-expect-error
-      deviceType: 'motorbike',
+      deviceType: /** @type {any} */ ('motorbike'),
       deleted: true,
     },
     expected: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,10 +31,7 @@ test('Bad docs throw when encoding', () => {
 
 test(`Bad docs won't validate`, () => {
   for (const { text, doc } of badDocs) {
-    assert.throws(() => {
-      // @ts-expect-error
-      validate(doc)
-    }, text)
+    assert(!validate(/** @type {any} */ (doc.schemaName), doc), text)
   }
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,8 +23,7 @@ import {
 test('Bad docs throw when encoding', () => {
   for (const { text, doc } of badDocs) {
     assert.throws(() => {
-      // @ts-expect-error
-      encode(doc)
+      encode(/** @type {any} */ (doc))
     }, text)
   }
 })
@@ -38,8 +37,10 @@ test(`Bad docs won't validate`, () => {
 test('validate bad docs', () => {
   for (const schemaName of Object.keys(currentSchemaVersions)) {
     assert(
-      // @ts-ignore
-      !validate(schemaName, {}),
+      !validate(
+        /** @type {keyof (typeof currentSchemaVersions)} */ (schemaName),
+        {}
+      ),
       `${schemaName} with missing properties should not validate`
     )
     assert(
@@ -59,7 +60,6 @@ test('validate good docs', () => {
     // skip docs with UNRECOGNIZED values - these are used for testing encoding/decoding and will not validate (the decoded versions should validate)
     if (Object.values(expected).includes('UNRECOGNIZED')) continue
     assert(
-      // @ts-ignore
       validate(doc.schemaName, valueOf(doc)),
       `${doc.schemaName} with all required properties should validate`
     )
@@ -95,11 +95,12 @@ test(`testing encoding of doc with additional optional values,
 test(`testing encoding of doc with additional extra values,
 then decoding and comparing the two objects - extra values shouldn't be present`, async () => {
   for (const { doc, expected } of goodDocsCompleted) {
-    const buf = encode({
-      ...doc,
-      // @ts-expect-error
-      extraFieldNotInSchema: 'whatever',
-    })
+    const buf = encode(
+      /** @type {any} */ ({
+        ...doc,
+        extraFieldNotInSchema: 'whatever',
+      })
+    )
     const decodedDoc = stripUndef(decode(buf, parseVersionId(doc.versionId)))
     assert.deepEqual(
       decodedDoc,


### PR DESCRIPTION
`validate`'s interface was inconsistent. Sometimes, it would `throw` an error; sometimes, it would return `false`. This makes it consistent: always return a boolean.

I discovered this when I noticed that a test wasn't passing the right arguments to `validate`. When I fixed it, I got test failures.

(You could argue that this should work the other way: it should throw instead of returning a boolean. But that's a bigger breaking change.)