### PR TITLE
chore: remove `ts-ignore` and `ts-expect-error`

### DIFF
--- a/scripts/lib/generate-jsonschema-exports.js
+++ b/scripts/lib/generate-jsonschema-exports.js
@@ -2,10 +2,7 @@
 import { default as _ } from '@json-schema-tools/dereferencer'
 
 // Dereferencer's exports are all wrong for ESM imports
-/** @type {any} */
-const JsonSchemaDereferencer =
-  // @ts-ignore
-  _.default
+const JsonSchemaDereferencer = /** @type {any} */ (_).default
 
 /** @typedef {import('../../src/types.js').SchemaName} SchemaName */
 /** @typedef {import('json-schema').JSONSchema7} JSONSchema */

--- a/scripts/lib/generate-jsonschema-ts.js
+++ b/scripts/lib/generate-jsonschema-ts.js
@@ -12,11 +12,18 @@ export async function generateJSONSchemaTS(config, jsonSchemas) {
   /** @type {Record<string, string>} */
   const typescriptDefs = {}
   for (const [schemaName, jsonSchema] of Object.entries(jsonSchemas.values)) {
-    // @ts-ignore
-    const ts = await compile(jsonSchema, capitalize(schemaName), {
-      additionalProperties: false,
-      unknownAny: false,
-    })
+    const ts = await compile(
+      /**
+       * This argument is a v7 JSON Schema but the function expects a v4 schema.
+       * It should be fine, so we cast it to `any`.
+       * @type {any}
+       */ (jsonSchema),
+      capitalize(schemaName),
+      {
+        additionalProperties: false,
+        unknownAny: false,
+      }
+    )
     typescriptDefs[schemaName] = ts
   }
 

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -21,7 +21,6 @@ import {
   convertTranslation,
   convertTrack,
 } from './lib/decode-conversions.js'
-// @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants.js'
 import {

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -5,7 +5,6 @@ import {
   type ValidSchemaDef,
 } from './types.js'
 import { currentSchemaVersions, dataTypeIds } from './config.js'
-// @ts-ignore
 import * as cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES } from './constants.js'
 import { Encode } from './proto/index.js'

--- a/src/typedefs/compact-encoding.d.ts
+++ b/src/typedefs/compact-encoding.d.ts
@@ -1,0 +1,1 @@
+declare module 'compact-encoding'

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -205,8 +205,7 @@ export const goodDocsCompleted = [
       updatedAt: cachedValues.updatedAt,
       links: [],
       name: 'my device name',
-      // @ts-expect-error
-      deviceType: 'motorbike',
+      deviceType: /** @type {any} */ ('motorbike'),
       deleted: true,
     },
     expected: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,8 +23,7 @@ import {
 test('Bad docs throw when encoding', () => {
   for (const { text, doc } of badDocs) {
     assert.throws(() => {
-      // @ts-expect-error
-      encode(doc)
+      encode(/** @type {any} */ (doc))
     }, text)
   }
 })
@@ -38,8 +37,10 @@ test(`Bad docs won't validate`, () => {
 test('validate bad docs', () => {
   for (const schemaName of Object.keys(currentSchemaVersions)) {
     assert(
-      // @ts-ignore
-      !validate(schemaName, {}),
+      !validate(
+        /** @type {keyof (typeof currentSchemaVersions)} */ (schemaName),
+        {}
+      ),
       `${schemaName} with missing properties should not validate`
     )
     assert(
@@ -59,7 +60,6 @@ test('validate good docs', () => {
     // skip docs with UNRECOGNIZED values - these are used for testing encoding/decoding and will not validate (the decoded versions should validate)
     if (Object.values(expected).includes('UNRECOGNIZED')) continue
     assert(
-      // @ts-ignore
       validate(doc.schemaName, valueOf(doc)),
       `${doc.schemaName} with all required properties should validate`
     )
@@ -95,11 +95,12 @@ test(`testing encoding of doc with additional optional values,
 test(`testing encoding of doc with additional extra values,
 then decoding and comparing the two objects - extra values shouldn't be present`, async () => {
   for (const { doc, expected } of goodDocsCompleted) {
-    const buf = encode({
-      ...doc,
-      // @ts-expect-error
-      extraFieldNotInSchema: 'whatever',
-    })
+    const buf = encode(
+      /** @type {any} */ ({
+        ...doc,
+        extraFieldNotInSchema: 'whatever',
+      })
+    )
     const decodedDoc = stripUndef(decode(buf, parseVersionId(doc.versionId)))
     assert.deepEqual(
       decodedDoc,


### PR DESCRIPTION
_Depends on #244._

This change should have no user impact.

There's almost always something better than `// @ts-ignore` and `// @ts-expect-error`. They can be problematic because they're very broad, and typically broader than we want. For details, see ["At least 7 reasons to avoid @ts-expect-error and @ts-ignore"][0].

This removes all of them in favor of more targeted solutions. (Or, in one case, just removes it and everything was fine!)

I think this is a useful change on its own, but it should make [an upcoming change][1] easier too.

[0]: https://shane-o.dev/articles/any-or-expect
[1]: https://github.com/digidem/mapeo-schema/pull/243