### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,4 +1,3 @@
-import type { SetOptional } from 'type-fest'
 import {
   type MapeoDocEncode,
   type SchemaName,
@@ -21,7 +20,6 @@ import {
   convertTranslation,
   convertTrack,
 } from './lib/encode-conversions.js'
-import { CoreOwnership } from './index.js'
 import { ExhaustivenessError } from './lib/utils.js'
 
 /**

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -17,12 +17,7 @@ import {
   type Observation_1_Attachment,
 } from '../proto/observation/v1.js'
 import { ExhaustivenessError, parseVersionId } from './utils.js'
-import {
-  CoreOwnership,
-  valueSchemas,
-  type Observation,
-  type Track,
-} from '../index.js'
+import { CoreOwnership, valueSchemas, type Observation } from '../index.js'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */


### PR DESCRIPTION
This change should have no user impact.

This removes a few unused imports from a few files.

I think this is a useful change on its own, but it should make [an upcoming change][1] easier too.

[1]: https://github.com/digidem/mapeo-schema/pull/243