### PR TITLE
chore: remove `any`s from decode helper function

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -140,10 +140,8 @@ function mutatingSetSchemaDef<T extends ProtoTypes, K extends ValidSchemaDef>(
   obj: T,
   props: K
 ): ProtoTypesWithSchemaInfo {
-  for (const prop of Object.keys(props)) {
-    ;(obj as any)[prop] = (props as any)[prop]
-  }
-  return obj as any
+  Object.assign(obj, props)
+  return obj as ProtoTypesWithSchemaInfo
 }
 
 // function mutatingOmit<T, K extends keyof any>(obj: T, key: K): OmitUnion<T, K> {


### PR DESCRIPTION
This change should have no user impact.

It's generally good to avoid `any`s, as they worsen type safety. This removes 3 of them in a `decode` helper function.