### PR TITLE
fix: observation metadata types

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,6 +7,8 @@ plugins:
     opt:
       - esModuleInterop=true
       - importSuffix=.js
+      - outputJsonMethods=false
+      - outputPartialMethods=false
       - env=node
       - snakeToCamel=false
       - useDate=string

--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -38,7 +38,7 @@ message Observation_1 {
 
   // METADATA
   message Metadata {
-    bool manualLocation = 1;
+    optional bool manualLocation = 1;
 
     message Position {
       google.protobuf.Timestamp timestamp = 1;
@@ -57,10 +57,10 @@ message Observation_1 {
     }
 
     message PositionProvider {
-      bool gpsAvailable = 1;
-      bool passiveAvailable = 2;
+      optional bool gpsAvailable = 1;
+      optional bool passiveAvailable = 2;
       bool locationServicesEnabled = 3;
-      bool networkAvailable = 4;
+      optional bool networkAvailable = 4;
     }
 
     optional Position position = 3;

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -7,6 +7,7 @@
     "position": {
       "description": "Position details",
       "type": "object",
+      "required": ["timestamp", "coords"],
       "properties": {
         "timestamp": {
           "description": "Timestamp of when the current position was obtained",
@@ -162,6 +163,7 @@
         "positionProvider": {
           "description": "Details of the location providers that were available on the device when the observation was recorded",
           "type": "object",
+          "required": ["locationServicesEnabled"],
           "properties": {
             "gpsAvailable": {
               "description": "Whether the user has enabled GPS for device location (this is not the same as whether location is turned on or off, this is a device setting whether to use just wifi and bluetooth or use GPS for location)",

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -482,10 +482,7 @@ function removeInvalidPositionMetadata(
 function removeInvalidPosition(
   position: Observation_1_Metadata_Position
 ): Position | undefined {
-  if (
-    typeof position.coords === 'undefined' ||
-    typeof position.timestamp === 'undefined'
-  ) {
+  if (position.coords === undefined || position.timestamp === undefined) {
     return undefined
   }
   return position as Position

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -100,7 +100,6 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...rest,
     attachments: message.attachments.map(convertAttachment),
     tags: convertTags(message.tags),
-    // Remove invalid position metadata if it's missing required fields
     metadata: metadata ? removeInvalidPositionMetadata(metadata) : {},
     presetRef,
   }

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -22,10 +22,15 @@ import {
 } from '../types.js'
 import { ExhaustivenessError, VersionIdObject, getVersionId } from './utils.js'
 import type { Observation, Track } from '../index.js'
-import type { Observation_1_Attachment } from '../proto/observation/v1.js'
+import type {
+  Observation_1_Attachment,
+  Observation_1_Metadata,
+  Observation_1_Metadata_Position,
+} from '../proto/observation/v1.js'
 import type { Track_1_Position } from '../proto/track/v1.js'
 import { ProjectSettings_1_ConfigMetadata } from '../proto/projectSettings/v1.js'
 import { ProjectSettings } from '../schema/projectSettings.js'
+import type { Position } from '../schema/observation.js'
 
 /** Function type for converting a protobuf type of any version for a particular
  * schema name, and returning the most recent JSONSchema type */
@@ -76,7 +81,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
   message,
   versionObj
 ) => {
-  const { common, schemaVersion, ...rest } = message
+  const { common, metadata, schemaVersion, ...rest } = message
   const jsonSchemaCommon = convertCommon(common, versionObj)
   let presetRef
 
@@ -95,7 +100,8 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...rest,
     attachments: message.attachments.map(convertAttachment),
     tags: convertTags(message.tags),
-    metadata: message.metadata,
+    // Remove invalid position metadata if it's missing required fields
+    metadata: metadata ? removeInvalidPositionMetadata(metadata) : {},
     presetRef,
   }
   return obs
@@ -452,4 +458,36 @@ function convertTrackPosition(
     coords: position.coords,
     timestamp: position.timestamp,
   }
+}
+
+/**
+ * Because of the way protobuf works, it's possible that a protobuf message is
+ * missing required fields. In this case `timestamp` and the `latitude` and
+ * `longitude` fields on `coords`. We shouldn't have any observations with these
+ * fields missing, but if we do, rather than throwing (and not indexing the
+ * observation at all), we remove the position metadata, since it is not useful
+ * without this metadata.
+ */
+function removeInvalidPositionMetadata(
+  metadata: Observation_1_Metadata
+): Observation['metadata'] {
+  const { position, lastSavedPosition, ...rest } = metadata
+  return {
+    ...rest,
+    position: position && removeInvalidPosition(position),
+    lastSavedPosition:
+      lastSavedPosition && removeInvalidPosition(lastSavedPosition),
+  }
+}
+
+function removeInvalidPosition(
+  position: Observation_1_Metadata_Position
+): Position | undefined {
+  if (
+    typeof position.coords === 'undefined' ||
+    typeof position.timestamp === 'undefined'
+  ) {
+    return undefined
+  }
+  return position as Position
 }

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -95,9 +95,6 @@ export const convertObservation: ConvertFunction<'observation'> = (
   mapeoDoc
 ) => {
   const attachments = mapeoDoc.attachments.map(convertAttachment)
-  const metadata: Observation_1_Metadata | undefined = mapeoDoc.metadata && {
-    ...Observation_1_Metadata.fromPartial(mapeoDoc.metadata),
-  }
   let presetRef
   if (mapeoDoc.presetRef) {
     presetRef = {
@@ -111,7 +108,6 @@ export const convertObservation: ConvertFunction<'observation'> = (
     ...mapeoDoc,
     attachments,
     tags: convertTags(mapeoDoc.tags),
-    metadata,
     presetRef,
   }
 }

--- a/test/fixtures/bad-docs.js
+++ b/test/fixtures/bad-docs.js
@@ -39,7 +39,6 @@ export const badDocs = [
           index: 123,
         }),
       ],
-      refs: [],
       attachments: [],
       tags: {},
       metadata: {},

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,7 @@ import {
   goodDocsCompleted,
   badDocs,
 } from './fixtures/index.js'
+import { cachedValues } from './fixtures/cached.js'
 
 test('Bad docs throw when encoding', () => {
   for (const { text, doc } of badDocs) {
@@ -223,6 +224,75 @@ test(`test encoding of wrongly formatted header`, async () => {
   assert.throws(() => {
     decodeBlockPrefix(buf)
   })
+})
+
+/** @type {import('../dist/index.js').Observation} */
+const minimalObservation = {
+  docId: cachedValues.docId,
+  versionId: cachedValues.versionId,
+  originalVersionId: cachedValues.originalVersionId,
+  schemaName: 'observation',
+  createdAt: cachedValues.createdAt,
+  updatedAt: cachedValues.updatedAt,
+  links: [],
+  lat: 24.0424,
+  lon: 21.0214,
+  attachments: [],
+  tags: {},
+  metadata: {},
+  deleted: false,
+}
+
+test(`encoding observation with missing position metadata`, async () => {
+  /** @type {import('../dist/index.js').Observation} */
+  const doc = {
+    ...minimalObservation,
+    metadata: {
+      position: /** @type {any} */ ({ coords: {} }),
+    },
+  }
+  const buf = encode(doc)
+  const decodedDoc = decode(buf, parseVersionId(doc.versionId))
+  assert.equal(decodedDoc.schemaName, 'observation')
+  // a previous bug meant that protobuf defaults of 0 were being set for lat/lon
+  assert.equal(
+    typeof decodedDoc.metadata?.position?.coords?.longitude,
+    'undefined'
+  )
+  assert.equal(
+    typeof decodedDoc.metadata?.position?.coords?.latitude,
+    'undefined'
+  )
+})
+
+test(`decoding observation with missing position provider props`, async () => {
+  /** @type {import('../dist/index.js').Observation} */
+  const doc = {
+    ...minimalObservation,
+    metadata: {
+      positionProvider: {
+        locationServicesEnabled: true,
+      },
+    },
+  }
+  const buf = encode(doc)
+  const decodedDoc = decode(buf, parseVersionId(doc.versionId))
+  assert.equal(decodedDoc.schemaName, 'observation')
+  assert.equal(
+    typeof decodedDoc.metadata?.positionProvider?.gpsAvailable,
+    'undefined',
+    'optional gpsAvailable prop should be undefined'
+  )
+  assert.equal(
+    typeof decodedDoc.metadata?.positionProvider?.networkAvailable,
+    'undefined',
+    'optional networkAvailable prop should be undefined'
+  )
+  assert.equal(
+    typeof decodedDoc.metadata?.positionProvider?.passiveAvailable,
+    'undefined',
+    'optional passiveAvailable prop should be undefined'
+  )
 })
 
 /**


### PR DESCRIPTION
boy protobuf and typescript are tricky beasts...

So there were a few edge-cases around the way we type, encode and decode observation position metadata.

We were using `fromPartial` for encoding metadata, which assigns defaults for missing props, which meant that decoding would pass type checks, but defaults would be assigned to the missing props, in this case `longitude` and `latitude`, which is a "null island" bug.

This PR makes a few changes:

- `manualLocation` is now optional in protobuf - the distinction between when this is `undefined` (when there is no location for the observation) and when it is boolean (when there is a location) is important.
- `gpsAvailable`, `networkAvailable`, `passiveAvailable` props of `metadata.positionProvider` are now optional on the protobuf, to distinguish between cases when this data is not available on the client (iOS) and when it is.
- `locationServicesEnabled` of `metadata.positionProvider` is now required on the JSONSchema - if we do store position provider metadata, then we have this data - this corresponds to the Expo types.
- `timestamp` and `coords` are now required fields of `position` and `lastSavedPosition` in the JSON schema. These metadata options don't make sense without this data.
- If a protobuf is missing `timestamp` or `coords` (possible, because of the way protobuf make everything optional), then we strip the position prop from metadata (rather than the alternative of assigning defaults or throwing)

This PR also removes usage of `fromPartial`, and stops generating it since it's no longer needed. Using this is "dangerous" because it assigns default values deeply to a message, which can lead to unexpected results - data that is type safe, but might have required fields set to default values.

**Impact on frontend**:

This is breaking, because it changes types to make some fields required. However fields that are newly set to required are also required / always set on the Expo Location [`LocationObject`](https://docs.expo.dev/versions/latest/sdk/location/#locationobject) and [`LocationProviderStatus`](https://docs.expo.dev/versions/latest/sdk/location/#locationproviderstatus). Therefore in frontend code this should not break things, because these values are being set from these objects from Expo.

These changes are not really specific to Expo - it would not make sense to add this metadata without these required fields being available, even if we move away from Expo for reading location.

**Why is this important?**

In the future, this (position) metadata is potentially important for "proofs" of observations. Without these changes it is possible that default values could be unexpectedly set, e.g. values could be `false` when they were actually unknown (`undefined`).
