### PR TITLE
chore: use upstream types for `compact-encoding`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@bufbuild/buf": "^1.26.1",
         "@json-schema-tools/dereferencer": "^1.6.3",
+        "@types/compact-encoding": "^2.15.0",
         "@types/json-schema": "^7.0.12",
         "ajv": "^8.12.0",
         "c8": "^8.0.1",
@@ -710,6 +711,12 @@
       "dependencies": {
         "@types/hast": "^3.0.4"
       }
+    },
+    "node_modules/@types/compact-encoding": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/compact-encoding/-/compact-encoding-2.15.0.tgz",
+      "integrity": "sha512-NmvvYrQC9QqbbEfm6ISHfCvvfQIwq53B4hZ7aAP6mEXsPc2F15Lkxj+jGzqVeKTT+Ir0HXAj4O9YUDsIpJbOuA==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@bufbuild/buf": "^1.26.1",
     "@json-schema-tools/dereferencer": "^1.6.3",
+    "@types/compact-encoding": "^2.15.0",
     "@types/json-schema": "^7.0.12",
     "ajv": "^8.12.0",
     "c8": "^8.0.1",

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -21,8 +21,7 @@ import {
   convertTranslation,
   convertTrack,
 } from './lib/decode-conversions.js'
-// @ts-ignore
-import * as cenc from 'compact-encoding'
+import cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES, SCHEMA_VERSION_BYTES } from './constants.js'
 import {
   ExhaustivenessError,

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -4,8 +4,7 @@ import {
   type ValidSchemaDef,
 } from './types.js'
 import { currentSchemaVersions, dataTypeIds } from './config.js'
-// @ts-ignore
-import * as cenc from 'compact-encoding'
+import cenc from 'compact-encoding'
 import { DATA_TYPE_ID_BYTES } from './constants.js'
 import { Encode } from './proto/index.js'
 import {


### PR DESCRIPTION
This is a types-only change.

[`@types/compact-encoding`][0] was recently published. Let's use that instead of ignoring the type.

[0]: https://www.npmjs.com/package/@types/compact-encoding